### PR TITLE
Add styling options for header size and card border radius.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,58 +12,64 @@ Just add the following into your README and set the query parameter `user` to yo
 
 ![My scrobbles](https://lastfm-recently-played.vercel.app/api?user=JeffreyCA01)
 
-### Link to Last.fm profile
+To add link to your last.fm profile, wrap the image in a link tag:
+
 ```md
 [![My Last.fm](https://lastfm-recently-played.vercel.app/api?user=JeffreyCA01)](https://www.last.fm/user/JeffreyCA01)
 ```
 
 [![My Last.fm](https://lastfm-recently-played.vercel.app/api?user=JeffreyCA01)](https://www.last.fm/user/JeffreyCA01)
 
-### Custom track count
-To a custom number of tracks, pass the query parameter `count` and set it to the number of tracks to display.
 
-> Default: `5`  
-> Min: `1`  
-> Max: `10`
+## Customization
 
-Example:
+### Parameters
+
+You can customize your list.fm status by adding query parameters after the url. Here is a list of available parameters.
+
+| Parameter | Description | Type | Default | Valid Values |
+| --- | --- | --- | --- | --- |
+| `count` | Number of recent tracks to display | number | 5 | 1 - 10 |
+| `width` | Width of the card in pixels | number | 400 | 300-1000 |
+| `loved` | Show a heart indicator for loved tracks | boolean | false | true, false |
+| `header_size` | Adjust the size of the header or hide it | string | normal | none, compact, normal |
+| `border_radius` | Adjust the radius of the card | number | 10 | 0 - 100 |
+| `loved_style` | Customize the indicator placement for loved tracks | number | 1 | 1, 2, 3, 4 |
+
+### Examples
+
+
+#### Customizing Track Count
+
 ```md
 ![My scrobbles](https://lastfm-recently-played.vercel.app/api?user=JeffreyCA01&count=1)
 ```
 
 ![My scrobbles](https://lastfm-recently-played.vercel.app/api?user=JeffreyCA01&count=1)
 
-### Custom card width
-To set a custom card width, pass the query parameter `width` and set it to the desired width in px.
+#### Customizing card width
 
-> Default: `400`  
-> Min: `300`  
-> Max: `1000`
-
-Example:
 ```md
 ![My scrobbles](https://lastfm-recently-played.vercel.app/api?user=JeffreyCA01&width=600)
 ```
 
 ![My scrobbles](https://lastfm-recently-played.vercel.app/api?user=JeffreyCA01&width=600)
 
-### Show loved tracks
-Set the `loved` parameter to `true` to show a heart indicator next to your loved tracks.
+#### Show loved tracks
 
-> Default: `false`
-
-Example:
 ```md
 ![My scrobbles](https://lastfm-recently-played.vercel.app/api?user=JeffreyCA01&loved=true)
 ```
 
 ![My scrobbles](https://lastfm-recently-played.vercel.app/api?user=JeffreyCA01&loved=true)
 
-**Further customization:**
+#### Header Sizes
 
-You can set the `loved_style` parameter to `1`, `2`, `3`, or `4` to customize the indicator placement.
+| `none` | `compact` | `normal` |
+| :----:    |    :----:   |  :----: |
+| ![](https://lastfm-recently-played.vercel.app/api?user=JeffreyCA01&width=300&count=2&header_size=none) | ![](https://lastfm-recently-played.vercel.app/api?user=JeffreyCA01&width=300&count=2&header_size=compact) | ![](https://lastfm-recently-played.vercel.app/api?user=JeffreyCA01&width=300&count=2&header_size=normal) |
 
-> Default: `1`
+#### Loved Style
 
 | Style 1 | Style 2 | Style 3 | Style 4 |
 | :----:    |    :----:   |  :----: | :----: |

--- a/components/SvgWidget.tsx
+++ b/components/SvgWidget.tsx
@@ -2,6 +2,7 @@
 // @ts-nocheck
 import { LovedTrackOptions } from '../models/LovedTrackOptions';
 import { RecentTracksResponse } from '../models/RecentTracksResponse';
+import { StyleOptions } from '../models/StyleOptions';
 import AntStyles from '../styles/antd';
 import SvgStyles from '../styles/svg';
 import TrackList from './TrackList/TrackList';
@@ -23,6 +24,10 @@ interface SvgWidgetProps {
      * Options for showing loved tracks.
      */
     lovedTrackOptions: LovedTrackOptions;
+    /**
+     * Options for styling the SVG.
+     */
+    styleOptions: StyleOptions;
 }
 
 /**
@@ -31,7 +36,7 @@ interface SvgWidgetProps {
 export default function SvgWidget(props: SvgWidgetProps): JSX.Element {
     const trackInfoList = props.recentTracksResponse.recenttracks.track;
     const username = props.recentTracksResponse.recenttracks['@attr'].user;
-    const { width, height, lovedTrackOptions } = props;
+    const { width, height, lovedTrackOptions, styleOptions } = props;
 
     return (
         <>
@@ -46,7 +51,7 @@ export default function SvgWidget(props: SvgWidgetProps): JSX.Element {
                     data-testid="card-bg"
                     x="0"
                     y="0"
-                    rx="10"
+                    rx={styleOptions.borderRadius}
                     height="100%"
                     stroke="#212121"
                     width={width}
@@ -54,11 +59,15 @@ export default function SvgWidget(props: SvgWidgetProps): JSX.Element {
                     strokeOpacity="1"
                 />
                 <foreignObject x="0" y="0" width={width} height={height}>
-                    <div xmlns="http://www.w3.org/1999/xhtml" style={{ color: 'white' }}>
+                    <div
+                        xmlns="http://www.w3.org/1999/xhtml"
+                        className={`svg-widget ${styleOptions.headerSize}`}
+                        style={{ color: 'white' }}>
                         <TrackList
                             trackInfoList={trackInfoList}
                             username={username}
                             lovedTrackOptions={lovedTrackOptions}
+                            styleOptions={styleOptions}
                         />
                     </div>
                 </foreignObject>

--- a/components/TrackList/TrackList.tsx
+++ b/components/TrackList/TrackList.tsx
@@ -3,6 +3,7 @@ import { LovedTrackOptions } from '../../models/LovedTrackOptions';
 import { TrackInfo } from '../../models/TrackInfo';
 import TrackListHeader from './TrackListHeader';
 import TrackListItem from './TrackListItem';
+import { StyleOptions } from '../../models/StyleOptions';
 
 interface Props {
     /**
@@ -17,19 +18,27 @@ interface Props {
      * Options for showing loved tracks.
      */
     lovedTrackOptions: LovedTrackOptions;
+    /**
+     * Options for styling.
+     */
+    styleOptions: StyleOptions;
 }
 
 /**
  * Track list component.
  */
 export default function TrackList(props: Props): JSX.Element {
-    const { trackInfoList, username, lovedTrackOptions } = props;
+    const { trackInfoList, username, lovedTrackOptions, styleOptions } = props;
     const anyLovesInList = trackInfoList.some((trackInfo) => trackInfo.loved === '1');
 
     return (
         <List
             size="small"
-            header={<TrackListHeader username={username} />}
+            header={
+                styleOptions.headerSize !== 'none' && (
+                    <TrackListHeader username={username} size={styleOptions.headerSize} />
+                )
+            }
             bordered
             dataSource={trackInfoList}
             renderItem={(trackInfo) => (

--- a/components/TrackList/TrackListHeader.tsx
+++ b/components/TrackList/TrackListHeader.tsx
@@ -1,5 +1,6 @@
 import { Image, Space, Typography } from 'antd';
 import LastFmIcon from '../../public/lastfm.svg';
+import { HeaderSize } from '../../models/StyleOptions';
 
 const { Text } = Typography;
 
@@ -8,24 +9,49 @@ interface Props {
      * Username.
      */
     username: string;
+    /**
+     * Size
+     */
+    size: HeaderSize;
 }
 
 /**
  * Track list header component.
  */
 export default function TrackListHeader(props: Props): JSX.Element {
-    return (
-        <div style={{ display: 'flex' }}>
-            <Space>
-                <a
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    href={`https://www.last.fm/user/${props.username}`}
-                    style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', marginTop: -1 }}>
-                    <Image preview={false} className="lastfm-icon" src={LastFmIcon} width={60}></Image>
-                </a>
-                <Text className="lastfm-title">Recently Played</Text>
-            </Space>
-        </div>
-    );
+    switch (props.size) {
+        case 'none':
+            return <></>;
+        case 'compact':
+            return (
+                <div style={{ display: 'flex', alignItems: 'center' }}>
+                    <Space>
+                        <a
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            href={`https://www.last.fm/user/${props.username}`}
+                            style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', marginTop: -1 }}>
+                            <Image preview={false} className="lastfm-icon" src={LastFmIcon} width={45}></Image>
+                        </a>
+                        <Text className="lastfm-title-compact">Recently Played</Text>
+                    </Space>
+                </div>
+            );
+        case 'normal':
+        default:
+            return (
+                <div style={{ display: 'flex' }}>
+                    <Space>
+                        <a
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            href={`https://www.last.fm/user/${props.username}`}
+                            style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', marginTop: -1 }}>
+                            <Image preview={false} className="lastfm-icon" src={LastFmIcon} width={60}></Image>
+                        </a>
+                        <Text className="lastfm-title">Recently Played</Text>
+                    </Space>
+                </div>
+            );
+    }
 }

--- a/models/StyleOptions.ts
+++ b/models/StyleOptions.ts
@@ -1,0 +1,6 @@
+export type HeaderSize = 'none' | 'compact' | 'normal';
+
+export interface StyleOptions {
+    headerSize: HeaderSize;
+    borderRadius: number;
+}

--- a/styles/svg.ts
+++ b/styles/svg.ts
@@ -10,6 +10,13 @@ svg {
     vertical-align: middle;
     font-size: 16px;
 }
+.lastfm-title-compact {
+    vertical-align: middle;
+    font-size: 10px;
+}
+.svg-widget.compact .ant-list-header {
+    padding: 3px 16px;
+}
 .lastfm-icon {
     margin-right: 10px;
 }

--- a/utils/SvgUtil.tsx
+++ b/utils/SvgUtil.tsx
@@ -3,24 +3,31 @@ import { flushToHTML } from 'styled-jsx/server';
 import SvgWidget from '../components/SvgWidget';
 import { LovedTrackOptions } from '../models/LovedTrackOptions';
 import { RecentTracksResponse } from '../models/RecentTracksResponse';
+import { HeaderSize, StyleOptions } from '../models/StyleOptions';
 
-const baseHeight = 40;
+const baseHeights: Record<HeaderSize, number> = {
+    none: 0,
+    compact: 24,
+    normal: 40,
+};
 const heightPerItem = 57;
 const heightBuffer = 5;
 
 export function generateSvg(
     recentTracksRes: RecentTracksResponse,
     width: number,
-    lovedTrackOptions: LovedTrackOptions
+    lovedTrackOptions: LovedTrackOptions,
+    styleOptions: StyleOptions
 ): string {
     const count = recentTracksRes.recenttracks.track.length;
-    const height = baseHeight + count * heightPerItem + heightBuffer;
+    const height = baseHeights[styleOptions.headerSize] + count * heightPerItem + heightBuffer;
     const svgBody = ReactDOMServer.renderToStaticMarkup(
         <SvgWidget
             width={width}
             height={height}
             recentTracksResponse={recentTracksRes}
             lovedTrackOptions={lovedTrackOptions}
+            styleOptions={styleOptions}
         />
     );
     const svgStyles = flushToHTML();


### PR DESCRIPTION
- Add parameter `header_size` to allow users customize header style or hide it completely
- Add parameter `border_radius` to allow users specify the card border radius
- Refactor README to make the documents more readable.

Examples for different header sizes:

|`none`|`compact`|`normal`|
|:---:|:---:|:---:|
|<img width="299" alt="image" src="https://github.com/JeffreyCA/lastfm-recently-played-readme/assets/11037722/875b1178-9acf-4f26-ab42-8b3dd124f173">|<img width="301" alt="image" src="https://github.com/JeffreyCA/lastfm-recently-played-readme/assets/11037722/127a77a9-8a97-499c-8e2b-78ee615d7c5f">|<img width="301" alt="image" src="https://github.com/JeffreyCA/lastfm-recently-played-readme/assets/11037722/0a0da083-bb49-41e4-9115-3abcc09b3c91">|

Note: I used your Vercel link in the updated README file, so you may need to deploy it in Vercel first to see examples for header sizes taking effect.

