### PR TITLE
Let callers set the card's colors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ Thumbs.db
 # Local agent tooling (Cloudflare skills), not part of the Worker.
 .agents/
 skills-lock.json
+commit-msg.txt
+msg.tmp
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,12 @@ npx wrangler secret put LASTFM_API_KEY   # production key; never in wrangler.jso
 
 Pushing to `main` runs typecheck + tests in GitHub Actions; Cloudflare Workers Builds deploys.
 
+## Conventions
+
+American spellings throughout - code, comments, docs and UI. The URL parameters
+are `bg_color`, `text_color` and so on, and prose that says "color" beside them
+reads as a different thing.
+
 ## What the rendering context forces
 
 GitHub renders the card inside an `<img>`, proxied by Camo. Almost every design decision follows from that:
@@ -27,10 +33,24 @@ GitHub renders the card inside an `<img>`, proxied by Camo. Almost every design 
 
 `profile` (`header` / `footer-left` / `footer-right` / `off`) says **where** your identity goes; `username` and `avatar` say **what's in it**. Folding placement into content is what once made the `avatar` toggle look header-only. The footer holds exactly **one** thing - when `profile` is in the footer, `footer` is ignored rather than stacked underneath.
 
+## Configurator
+
+`public/` is plain HTML, CSS and JS with no build step, and the page's whole job is to assemble a URL string.
+
+- **Only values that differ from the theme reach the URL.** The color fields are filled in with whatever the card is using, so they can be copied out, and a field equal to its theme value is treated as unset. Resetting writes the theme's value back.
+- **Color swatches are bound to `change`, not `input`.** A native picker fires continuously while dragging and every preview is a request to the Worker.
+- `THEME_COLORS` mirrors each theme's settable colors from `render/themes.ts`. Update both together, or an untouched picker shows a color the card isn't using.
+- The form is a fixed 500px and the preview takes the remaining width, because the card can be up to 1000px wide and the form cannot usefully use more. Card height changes with track count, but the preview is in its own column, so it never reflows the form.
+
 ## Gotchas
 
 - **Every string from Last.fm goes through `escapeXml`.** One bare `&` breaks the entire image, silently, with nothing in any log. This is the most common way to ship a broken card.
-- **Caller-supplied colours are validated, not escaped.** `bg_color` is interpolated into an SVG attribute, so `parseHexColour` allowlists a strict hex shape and returns null otherwise.
+- **Caller-supplied colors are validated, not escaped.** Every color parameter is interpolated into an SVG attribute, so `parseHexColor` allowlists a strict hex shape and returns null otherwise. Any new color parameter must go through it - this is a security boundary, not a formatting preference.
+- **Most of `Theme` is derived, not chosen.** `bg_color`, `text_color`, `artist_color`, `meta_color`, `accent_color` and `loved_color` are the only settable palette colors; the dividers, borders and placeholders are mixes between the text color and the background (`render/color.ts`), using ratios measured from the presets. They are named as **roles, not elements** - `meta` is the timestamps, the footer and the stats labels together. `resolveTheme` returns the preset object itself when nothing is overridden, and a test asserts that by identity, so existing cards cannot drift.
+- **`logo_color` is not part of `Theme`.** The wordmark is a trademark, so it defaults to Last.fm's red in every palette and lives as an option rather than a theme field.
+- **`artist` and `meta` are two controls on purpose.** Deriving one from the other is within 6/255 on the neutral themes and out by 21 and 41 on `nord` and `catppuccin`, which pair a hued artist line with a neutral grey timestamp - the derivation turns that grey blue or purple. They were merged into one `muted_color` and it had to be undone; the configurator links them by default instead, which is a convenience in that page only. The URL always carries both colors in full, so the Worker has no notion of linking and a hand-edited URL cannot reach a state the form cannot show.
+- **`loved` is separate from `accent` only because of `nord`.** Its accent is blue and a blue heart reads as something else; the other five presets set the two to the same color. Don't "simplify" it away.
+- **A background can make a theme unreadable.** `?bg_color=ffffff` on `dark` once painted near-white text onto white. `resolveTheme` now borrows the inks from whichever built-in palette suits the background when contrast fails. Changing the derivation ratios changes every custom card at once and only in the rendering, so the tests pin them.
 - **`isAllowedArtUrl` is a security boundary.** Without it the endpoint is an open proxy. The real CDN host is `lastfm-img.freetls.fastly.net` - note the `-img`; guessing it wrong fails silently and every cover falls back to a placeholder. Art fetches use `redirect: 'manual'`, since the allowlist only validates the URL we start with; a 3xx then fails the `res.ok` check.
 - **Workers only implement `redirect: 'follow'` and `'manual'`.** `'error'` throws a `TypeError` on the edge, and local `wrangler dev` does *not* reproduce it - this shipped once and broke every cover in production while looking perfect locally. Verify subrequest behaviour against a real deploy or `wrangler dev --remote`, not just local.
 - **`user.getRecentTracks` returns `track` as a bare object, not an array, for a single result.**
@@ -52,8 +72,10 @@ GitHub renders the card inside an `<img>`, proxied by Camo. Almost every design 
 
 ## Testing
 
-Deliberately minimal (8 tests) and it should stay that way while the design is still moving. It covers what fails *silently*: well-formed and escaped SVG, untrusted input (track URLs, art hosts, usernames), the upstream response shapes, and the HTTP contract.
+Deliberately minimal and it should stay that way while the design is still moving. It covers what fails *silently*: well-formed and escaped SVG, untrusted input (track URLs, art hosts, usernames), the upstream response shapes, the HTTP contract, and the color maths - a wrong mix ratio or a dropped contrast check produces a card that renders perfectly and just looks wrong.
 
 **Don't add pixel-position assertions.** They were tried; every layout change broke them and the test was wrong every time. Verify visual work by rendering against `npm run dev` and looking at it.
+
+The color tests are the exception that proves the rule: they assert ratios and contrast, never positions. Their tolerances are set from measured error against the presets (worst case 22/255, in `meta` for `nord` and `border` for `light`) rather than picked to make the suite pass - a tolerance tightened past the real spread will fail on a theme nobody touched.
 
 Static assets aren't served through `SELF.fetch` in vitest-pool-workers - the runtime handles them before the Worker - so the configurator is only verifiable against a real dev server.

--- a/README.md
+++ b/README.md
@@ -65,19 +65,9 @@ Booleans also accept `true`/`false`, `yes`/`no`, `on`/`off`. Numbers outside the
 
 ### Colors
 
-Each color parameter layers on top of the chosen theme and is optional - anything you leave out keeps following the theme, so a URL only ever carries what you actually changed. All of them take 3, 4, 6 or 8 hex digits with no leading `#` (4 and 8 include alpha).
+Every color takes 3, 4, 6 or 8 hex digits (without leading `#`) - 4 and 8 include alpha.
 
-These are roles rather than single elements - `meta_color` covers the timestamps, the footer and the stats labels together - and everything else the card draws is derived from them: the row dividers, the artwork placeholders, the muted heart. Those are relationships rather than decisions, and mixing `text_color` with `bg_color` reproduces the built-in themes' own supporting colors closely.
-
-`artist_color` and `meta_color` look like one control and are not. In the neutral themes the timestamp is the artist color faded a little further, but `nord` and `catppuccin` deliberately pair a colored artist line with a neutral grey timestamp. The configurator links the two by default and lets you break the link.
-
-`loved_color` is separate from `accent_color` for the same kind of reason: `nord`'s accent is blue, and a blue heart reads as something else entirely. In the other themes the two are the same color.
-
-`logo_color` is the exception to all of it: the wordmark is Last.fm's trademark, so it stays their red in every theme unless you deliberately change it.
-
-If a background is picked that the theme's text can't be read against, the card takes its text colors from whichever built-in palette suits that background instead of rendering something illegible. So `?bg_color=ffffff` on the dark theme gives dark text, not white-on-white. Set `text_color` yourself to override that.
-
-The [configurator](https://lastfm-recently-played.jeffreyca.workers.dev) has a picker for each one and shows the text contrast as you go.
+`bg_color` is safe on its own: the card picks readable text for whatever background you give it, so `?bg_color=ffffff` on the dark theme comes out dark-on-white rather than white-on-white. Set `text_color` to choose for yourself.
 
 ### Loved tracks
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Add parameters to the URL, e.g. `?user=JeffreyCA01&theme=light&count=3`.
 | --- | --- | --- | --- |
 | `user` | Whose scrobbles to show | *required* | Last.fm username |
 | `count` | How many tracks. A now-playing track counts as one | `5` | `1`-`10` |
-| `theme` | Color scheme | `dark` | `dark`, `legacy`, `light`, `nord`, `catppuccin`, `transparent` |
+| `theme` | Color scheme | `dark` | `dark`, `legacy`, `light`, `dracula`, `tokyonight`, `nord`, `catppuccin`, `transparent` |
 | `bg_color` | Card background | theme's | hex digits, no `#` - e.g. `212121` |
 | `text_color` | Track titles. Dividers, borders and placeholders follow it | theme's | hex digits, no `#` |
 | `artist_color` | The artist line | theme's | hex digits, no `#` |

--- a/README.md
+++ b/README.md
@@ -40,8 +40,14 @@ Add parameters to the URL, e.g. `?user=JeffreyCA01&theme=light&count=3`.
 | --- | --- | --- | --- |
 | `user` | Whose scrobbles to show | *required* | Last.fm username |
 | `count` | How many tracks. A now-playing track counts as one | `5` | `1`-`10` |
-| `theme` | Colour scheme | `dark` | `dark`, `legacy`, `light`, `nord`, `catppuccin`, `transparent` |
-| `bg_color` | Background colour only. Text colours stay as the theme has them | theme's | hex digits, no `#` - e.g. `212121` |
+| `theme` | Color scheme | `dark` | `dark`, `legacy`, `light`, `nord`, `catppuccin`, `transparent` |
+| `bg_color` | Card background | theme's | hex digits, no `#` - e.g. `212121` |
+| `text_color` | Track titles. Dividers, borders and placeholders follow it | theme's | hex digits, no `#` |
+| `artist_color` | The artist line | theme's | hex digits, no `#` |
+| `meta_color` | Timestamps, the footer and the stats labels | theme's | hex digits, no `#` |
+| `accent_color` | The now-playing bars, "Scrobbling now", and title hover | theme's | hex digits, no `#` |
+| `loved_color` | The loved-track heart | theme's | hex digits, no `#` |
+| `logo_color` | The Last.fm wordmark | `d51007` | hex digits, no `#` |
 | `width` | Card width in pixels | `400` | `260`-`1000` |
 | `radius` | Corner rounding | `10` | `0`-`40` |
 | `art` | Album artwork | `1` | `1` / `0` |
@@ -56,6 +62,22 @@ Add parameters to the URL, e.g. `?user=JeffreyCA01&theme=light&count=3`.
 | `loved` | Where to mark tracks you've hearted | `time` | `off`, `between`, `between-all`, `title`, `time` |
 
 Booleans also accept `true`/`false`, `yes`/`no`, `on`/`off`. Numbers outside their range are clamped rather than rejected.
+
+### Colors
+
+Each color parameter layers on top of the chosen theme and is optional - anything you leave out keeps following the theme, so a URL only ever carries what you actually changed. All of them take 3, 4, 6 or 8 hex digits with no leading `#` (4 and 8 include alpha).
+
+These are roles rather than single elements - `meta_color` covers the timestamps, the footer and the stats labels together - and everything else the card draws is derived from them: the row dividers, the artwork placeholders, the muted heart. Those are relationships rather than decisions, and mixing `text_color` with `bg_color` reproduces the built-in themes' own supporting colors closely.
+
+`artist_color` and `meta_color` look like one control and are not. In the neutral themes the timestamp is the artist color faded a little further, but `nord` and `catppuccin` deliberately pair a colored artist line with a neutral grey timestamp. The configurator links the two by default and lets you break the link.
+
+`loved_color` is separate from `accent_color` for the same kind of reason: `nord`'s accent is blue, and a blue heart reads as something else entirely. In the other themes the two are the same color.
+
+`logo_color` is the exception to all of it: the wordmark is Last.fm's trademark, so it stays their red in every theme unless you deliberately change it.
+
+If a background is picked that the theme's text can't be read against, the card takes its text colors from whichever built-in palette suits that background instead of rendering something illegible. So `?bg_color=ffffff` on the dark theme gives dark text, not white-on-white. Set `text_color` yourself to override that.
+
+The [configurator](https://lastfm-recently-played.jeffreyca.workers.dev) has a picker for each one and shows the text contrast as you go.
 
 ### Loved tracks
 

--- a/public/app.js
+++ b/public/app.js
@@ -7,7 +7,7 @@
  */
 
 const USERNAME_RE = /^[a-zA-Z][a-zA-Z0-9_-]{1,29}$/;
-/** Mirrors parseHexColour on the server: hex digits only, no leading hash. */
+/** Mirrors parseHexColor on the server: hex digits only, no leading hash. */
 const HEX_RE = /^([0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
 
 /**
@@ -21,6 +21,12 @@ const SAMPLE_USER = 'rj';
 const DEFAULTS = {
   theme: 'dark',
   bg_color: '',
+  text_color: '',
+  artist_color: '',
+  meta_color: '',
+  accent_color: '',
+  loved_color: '',
+  logo_color: '',
   count: 5,
   width: 400,
   radius: 10,
@@ -36,12 +42,108 @@ const DEFAULTS = {
   loved: 'time',
 };
 
+/**
+ * Each color control: its element id prefix, its URL parameter, and where its
+ * default comes from - a theme field, or a fixed value for the wordmark, which
+ * is a trademark rather than part of any palette. One table so the swatches,
+ * resets, placeholders and URL builder cannot disagree about what a field means.
+ */
+const COLORS = [
+  { id: 'bg-color', param: 'bg_color', themeKey: 'bg' },
+  { id: 'text-color', param: 'text_color', themeKey: 'title' },
+  { id: 'artist-color', param: 'artist_color', themeKey: 'artist' },
+  { id: 'meta-color', param: 'meta_color', themeKey: 'meta' },
+  { id: 'accent-color', param: 'accent_color', themeKey: 'accent' },
+  { id: 'loved-color', param: 'loved_color', themeKey: 'loved' },
+  { id: 'logo-color', param: 'logo_color', fixed: '#d51007' },
+];
+
+const COLOR_BY_PARAM = new Map(COLORS.map((c) => [c.param, c]));
+
+const MIN_CONTRAST = 4.5;
+
+/**
+ * How far past the artist line the timestamp sits, toward the background. The
+ * presets put the artist at 31% of the way from the title and the timestamp at
+ * 48%, so from the artist it is a further 25% of what remains.
+ */
+const META_FROM_ARTIST = 0.25;
+
+/**
+ * How far a theme's own timestamp may sit from that relationship and still
+ * count as linked. The presets land at 2-6 when they follow it, 21 and 41 when
+ * they don't, so anything between separates them.
+ */
+const LINK_TOLERANCE = 10;
+
+/**
+ * Each theme's settable colors, mirrored from themes.ts so a swatch can show
+ * what is actually rendering. `transparent` has no background, so it seeds from
+ * the card it is usually laid over.
+ */
+const THEME_COLORS = {
+  dark: {
+    bg: '#151b23',
+    title: '#e9eef5',
+    artist: '#9fadbd',
+    meta: '#7d8b9c',
+    accent: '#d51007',
+    loved: '#e02d24',
+  },
+  legacy: {
+    bg: '#212121',
+    title: '#f0f0f0',
+    artist: '#b0b0b0',
+    meta: '#8a8a8a',
+    accent: '#d51007',
+    loved: '#e02d24',
+  },
+  light: {
+    bg: '#ffffff',
+    title: '#1f2328',
+    artist: '#59636e',
+    meta: '#818b98',
+    accent: '#d51007',
+    loved: '#d51007',
+  },
+  nord: {
+    bg: '#2e3440',
+    title: '#eceff4',
+    artist: '#88c0d0',
+    meta: '#7b88a1',
+    accent: '#88c0d0',
+    loved: '#bf616a',
+  },
+  catppuccin: {
+    bg: '#1e1e2e',
+    title: '#cdd6f4',
+    artist: '#cba6f7',
+    meta: '#7f849c',
+    accent: '#f38ba8',
+    loved: '#f38ba8',
+  },
+  transparent: {
+    bg: '#0d1117',
+    title: '#8b949e',
+    artist: '#8b949e',
+    meta: '#6e7681',
+    accent: '#d51007',
+    loved: '#d51007',
+  },
+};
+
 const el = (id) => document.getElementById(id);
 
 const controls = {
   user: el('user'),
   theme: el('theme'),
   bg_color: el('bg-color'),
+  text_color: el('text-color'),
+  artist_color: el('artist-color'),
+  meta_color: el('meta-color'),
+  accent_color: el('accent-color'),
+  loved_color: el('loved-color'),
+  logo_color: el('logo-color'),
   count: el('count'),
   width: el('width'),
   radius: el('radius'),
@@ -64,20 +166,22 @@ const out = {
   snippet: el('snippet-out'),
   url: el('url-out'),
   userError: el('user-error'),
-  bgColorError: el('bg-color-error'),
+  colorStatus: el('color-status'),
+  colorCount: el('color-count'),
   preview: el('preview'),
   previewEmpty: el('preview-empty'),
+  previewScale: el('preview-scale'),
   copy: el('copy'),
   copyUrl: el('copy-url'),
 };
 
 let activeTab = 'markdown';
 
-function readState() {
-  return {
+/** The controls as they stand, before the artist/timestamp link is applied. */
+function readRawState() {
+  const state = {
     user: controls.user.value.trim(),
     theme: controls.theme.value,
-    bg_color: controls.bg_color.value.trim().replace(/^#/, ''),
     count: Number(controls.count.value),
     width: Number(controls.width.value),
     radius: Number(controls.radius.value),
@@ -92,6 +196,22 @@ function readState() {
     footer: controls.footer.value,
     loved: controls.loved.value,
   };
+  for (const { param } of COLORS) {
+    state[param] = controls[param].value.trim().toLowerCase().replace(/^#/, '');
+  }
+  return state;
+}
+
+function readState() {
+  const state = readRawState();
+  // The timestamp is the artist color's to give while they are linked - but
+  // only once there is something to derive from, so an untouched theme keeps
+  // its own pair rather than a computed approximation of it.
+  if (isLinked(state) && (customized.has('artist_color') || !themeIsLinked(state.theme))) {
+    state.meta_color = linkedMetaValue(state);
+    customized.add('meta_color');
+  }
+  return state;
 }
 
 /** Builds the widget URL, omitting anything left at its default to keep it short. */
@@ -118,9 +238,11 @@ function buildUrl(state, overrides = {}) {
   if (merged.footer !== DEFAULTS.footer && !merged.profile.startsWith('footer-'))
     params.set('footer', merged.footer);
   if (merged.loved !== DEFAULTS.loved) params.set('loved', merged.loved);
-  // Only emit a colour once it's actually valid, so a half-typed hex doesn't
-  // produce a snippet that renders differently from the preview.
-  if (HEX_RE.test(merged.bg_color)) params.set('bg_color', merged.bg_color);
+  // Only colors that differ from the theme, so the fields can sit filled in
+  // without every card carrying six redundant parameters.
+  for (const { param } of COLORS) {
+    if (HEX_RE.test(merged[param]) && isCustom(param, merged)) params.set(param, merged[param]);
+  }
 
   return `${location.origin}/svg?${params.toString()}`;
 }
@@ -169,6 +291,209 @@ function schedulePreview(url) {
   }, 300);
 }
 
+/* -------------------------------------------------------------------------- */
+/* Colors                                                                      */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * A small mirror of src/render/color.ts, duplicated because this page has no
+ * build step. It drives the swatches, placeholders and contrast readout only -
+ * the rendered card always comes from the Worker.
+ */
+
+/** Expands the short forms, so a swatch can be seeded from any accepted hex. */
+function toSixDigit(value) {
+  if (!HEX_RE.test(value)) return null;
+  const hex = value.length <= 4 ? [...value].map((c) => c + c).join('') : value;
+  return `#${hex.slice(0, 6)}`;
+}
+
+function channels(sixDigit) {
+  return [1, 3, 5].map((i) => Number.parseInt(sixDigit.slice(i, i + 2), 16));
+}
+
+function mixHex(from, to, t) {
+  const a = channels(from);
+  const b = channels(to);
+  const hex = a.map((v, i) =>
+    Math.round(v + (b[i] - v) * t)
+      .toString(16)
+      .padStart(2, '0'),
+  );
+  return `#${hex.join('')}`;
+}
+
+/** WCAG relative luminance. */
+function luminance(sixDigit) {
+  const [r, g, b] = channels(sixDigit).map((raw) => {
+    const c = raw / 255;
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+function contrast(a, b) {
+  const la = luminance(a);
+  const lb = luminance(b);
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+}
+
+function themeColors(theme) {
+  return THEME_COLORS[theme] ?? THEME_COLORS.dark;
+}
+
+/**
+ * The color a field falls back to, as `#rrggbb`, or null where the theme has
+ * none to offer - only `transparent`'s background, which the card does not
+ * draw at all.
+ */
+function themeDefault(param, state) {
+  const { themeKey, fixed } = COLOR_BY_PARAM.get(param);
+  if (fixed) return fixed;
+  if (param === 'bg_color' && state.theme === 'transparent') return null;
+  return themeColors(state.theme)[themeKey];
+}
+
+/** What the card will use for a color, given what is typed and which theme. */
+function effectiveColor(param, state) {
+  return (
+    toSixDigit(state[param]) ??
+    themeDefault(param, state) ??
+    themeColors(state.theme).bg
+  );
+}
+
+/** Whether a field is carrying anything other than its theme default. */
+function isCustom(param, state) {
+  if (!customized.has(param)) return false;
+  return state[param] !== '' && HEX_RE.test(state[param]);
+}
+
+/**
+ * The color fields a user has actually set.
+ *
+ * Tracked rather than inferred by comparing against the theme, because the
+ * fields are filled in with the theme's own values: a comparison cannot tell
+ * "untouched" from "deliberately set to the same color", and every field would
+ * turn custom the moment the theme changed under it.
+ */
+const customized = new Set();
+
+/* -------------------------------------------------------------------------- */
+/* Artist / timestamp link                                                     */
+/* -------------------------------------------------------------------------- */
+
+/*
+ * The two are one relationship in the neutral themes and deliberately unalike
+ * in nord and catppuccin, so the page offers a link rather than the API. The
+ * URL always carries both colors in full: the Worker needs no notion of
+ * linking, and a hand-edited URL cannot reach a state this form cannot show.
+ */
+
+/** Null until the toggle is used, so the theme answers for itself until then. */
+let linkChoice = null;
+
+/** The timestamp color implied by an artist color. */
+function derivedMeta(artist, bg) {
+  return mixHex(artist, bg, META_FROM_ARTIST);
+}
+
+/** Whether a theme's own pair already follows that relationship. */
+function themeIsLinked(theme) {
+  const colors = themeColors(theme);
+  const derived = channels(derivedMeta(colors.artist, colors.bg));
+  return channels(colors.meta).every((v, i) => Math.abs(v - derived[i]) <= LINK_TOLERANCE);
+}
+
+function isLinked(state) {
+  return linkChoice ?? themeIsLinked(state.theme);
+}
+
+/**
+ * The timestamp color the link implies. Always a value now that the fields are
+ * filled in - whether it reaches the URL is decided by `isCustom`.
+ */
+function linkedMetaValue(state) {
+  return derivedMeta(
+    effectiveColor('artist_color', state),
+    effectiveColor('bg_color', state),
+  ).replace(/^#/, '');
+}
+
+/**
+ * Writes the state back onto the controls: swatches, placeholders, validity,
+ * the link, and the contrast readout.
+ *
+ * Contrast warns rather than blocks. Low contrast can be deliberate, and the
+ * server quietly rescues unreadable combinations - saying nothing would make
+ * that look like the color being ignored.
+ */
+function syncColors(state) {
+  const linked = isLinked(state);
+  el('link-artist-meta').setAttribute('aria-pressed', String(linked));
+
+  let invalid = 0;
+
+  for (const { id, param } of COLORS) {
+    const raw = state[param];
+    const bad = raw !== '' && !HEX_RE.test(raw);
+    if (bad) invalid++;
+
+    const input = controls[param];
+    input.setAttribute('aria-invalid', String(bad));
+
+    // Fields carry the value the card is using rather than a placeholder, so a
+    // theme's palette can be read and copied straight out. Untouched fields
+    // follow the theme; `transparent` has no background to name, so that one
+    // field stays empty.
+    const fallback = themeDefault(param, state);
+    if (!customized.has(param)) input.value = fallback ? fallback.slice(1) : '';
+    else if (param === 'meta_color' && linked) input.value = state.meta_color;
+    input.placeholder = fallback ? '' : 'none';
+
+    const row = document.querySelector(`.color-row[data-color="${id}"]`);
+    row.dataset.unset = String(!isCustom(param, state));
+    if (param === 'meta_color') {
+      row.dataset.linked = String(linked);
+      // Readonly rather than disabled, so the derived value can still be
+      // selected and copied.
+      input.readOnly = linked;
+    }
+
+    // A chequer means transparency, which only 4- and 8-digit hex carries.
+    row.querySelector('.swatch-wrap').dataset.alpha = String(
+      raw.length === 4 || raw.length === 8,
+    );
+
+    const swatch = el(`${id}-swatch`);
+    // Not while the pointer is inside the native picker, which would fight it.
+    if (document.activeElement !== swatch) swatch.value = effectiveColor(param, state);
+  }
+
+  if (invalid > 0) {
+    out.colorStatus.dataset.level = 'error';
+    out.colorStatus.textContent = 'Hex digits only, e.g. 212121 or 212121cc';
+    return;
+  }
+
+  const ratio = contrast(effectiveColor('bg_color', state), effectiveColor('text_color', state));
+  const readable = ratio >= MIN_CONTRAST;
+  out.colorStatus.dataset.level = readable ? 'ok' : 'warn';
+  out.colorStatus.textContent = readable
+    ? `Text contrast ${ratio.toFixed(1)}:1`
+    : `Text contrast ${ratio.toFixed(1)}:1 - the card will adjust the text to stay readable.`;
+}
+
+/**
+ * Counts the colors in play on the collapsed section's summary, so customising
+ * one is not hidden by closing it.
+ */
+function updateColorBadge(state) {
+  const set = COLORS.filter(({ param }) => isCustom(param, state)).length;
+  out.colorCount.hidden = set === 0;
+  out.colorCount.textContent = String(set);
+}
+
 function render() {
   const state = readState();
 
@@ -183,13 +508,8 @@ function render() {
   // Only say something when something is wrong.
   out.userError.textContent = empty || valid ? '' : 'Not a valid username';
 
-  const colour = state.bg_color;
-  out.bgColorError.textContent =
-    colour === '' || HEX_RE.test(colour) ? '' : 'Hex digits only, e.g. 212121';
-  controls.bg_color.setAttribute(
-    'aria-invalid',
-    String(colour !== '' && !HEX_RE.test(colour)),
-  );
+  syncColors(state);
+  updateColorBadge(state);
 
   // The footer holds one thing. If the profile is down there, it is the footer.
   controls.footer.disabled = state.profile.startsWith('footer-');
@@ -240,10 +560,53 @@ async function copyText(text, button) {
   }, 1400);
 }
 
-for (const control of Object.values(controls)) {
+const COLOR_PARAMS = new Set(COLORS.map((c) => c.param));
+
+for (const [name, control] of Object.entries(controls)) {
+  // A color field claims itself as the user's before anything re-renders from
+  // it - otherwise the render would overwrite what was just typed.
+  if (COLOR_PARAMS.has(name)) {
+    control.addEventListener('input', () => {
+      if (control.value.trim() === '') customized.delete(name);
+      else customized.add(name);
+    });
+  }
   control.addEventListener('input', render);
   control.addEventListener('change', render);
 }
+
+/*
+ * Swatches bind to `change`, not `input`: a native picker fires `input`
+ * continuously while dragging, and every preview is a request to the Worker.
+ */
+for (const { id, param } of COLORS) {
+  const swatch = el(`${id}-swatch`);
+
+  swatch.addEventListener('change', () => {
+    controls[param].value = swatch.value.replace(/^#/, '');
+    customized.add(param);
+    render();
+  });
+
+  // Resetting hands the field back to the theme; the next render fills it with
+  // the theme's own value, which then stays out of the URL.
+  document.querySelector(`.reset[data-reset="${id}"]`).addEventListener('click', () => {
+    customized.delete(param);
+    if (param === 'artist_color' || param === 'meta_color') {
+      linkChoice = null;
+      customized.delete('meta_color');
+    }
+    render();
+    controls[param].focus();
+  });
+}
+
+el('link-artist-meta').addEventListener('click', () => {
+  // Taken from what is currently showing, so the first click always visibly
+  // does something whichever way the theme started.
+  linkChoice = !isLinked(readState());
+  render();
+});
 
 for (const tab of document.querySelectorAll('.tab')) {
   tab.addEventListener('click', () => {
@@ -271,6 +634,22 @@ out.preview.addEventListener('error', () => {
   out.previewEmpty.textContent = 'Preview failed to load';
 });
 
+/**
+ * Says so when the card is being shown smaller than it will render. Without it
+ * a wide card just looks like it has small type, and the width slider appears
+ * to do nothing beyond a certain point.
+ */
+out.preview.addEventListener('load', () => {
+  const natural = out.preview.naturalWidth;
+  const shown = out.preview.clientWidth;
+  const scaled = natural > 0 && shown > 0 && shown < natural - 1;
+
+  out.previewScale.hidden = !scaled;
+  if (scaled) {
+    out.previewScale.textContent = `Shown at ${Math.round((shown / natural) * 100)}% - the card is ${natural}px wide.`;
+  }
+});
+
 // Deep-link support: /?user=foo&theme=nord prefills the form.
 (function hydrateFromQuery() {
   const q = new URLSearchParams(location.search);
@@ -282,7 +661,12 @@ out.preview.addEventListener('error', () => {
   if (q.has('loved')) controls.loved.value = q.get('loved');
   if (q.has('footer')) controls.footer.value = q.get('footer');
   if (q.has('profile')) controls.profile.value = q.get('profile');
-  if (q.has('bg_color')) controls.bg_color.value = q.get('bg_color');
+  // A color in the URL was chosen deliberately, so it counts as the user's.
+  for (const { param } of COLORS) {
+    if (!q.has(param)) continue;
+    controls[param].value = q.get(param);
+    customized.add(param);
+  }
   if (q.has('stats')) {
     // `stats=1` still means "show them", as the endpoint accepts.
     const raw = q.get('stats');
@@ -293,6 +677,22 @@ out.preview.addEventListener('error', () => {
   for (const name of ['art', 'header', 'time', 'logo', 'username', 'avatar']) {
     if (q.has(name)) controls[name].checked = bool(q.get(name));
   }
+
+  // Open the colors section when a link arrives with colors already set,
+  // so the controls that produced the card are the ones on screen.
+  if (COLORS.some(({ param }) => q.has(param))) {
+    el('colors-details').open = true;
+  }
+
+  // A shared link carries both colors whether or not they were linked here.
+  // Read the controls before the link is applied and ask whether the timestamp
+  // is exactly what the artist color implies; if not, it was chosen
+  // deliberately and must not be overwritten.
+  if (q.has('meta_color')) {
+    const raw = readRawState();
+    linkChoice = raw.meta_color === linkedMetaValue(raw);
+  }
+
   render();
 
   focusUsernameIfHelpful(q.has('user'));
@@ -300,16 +700,9 @@ out.preview.addEventListener('error', () => {
 
 /**
  * Puts the caret in the username field on load, since replacing the sample name
- * is the first thing anyone does here. Skipped in the two cases where it would
- * be a nuisance rather than a shortcut:
- *
- * - Arriving by deep link, where the form is already the configuration someone
- *   wanted to see, and selecting the username invites wiping it by mistake.
- * - Touch devices, where focusing a text input raises the on-screen keyboard
- *   over the page before anyone has asked to type.
- *
- * `preventScroll` keeps the page at the top: the field is above the fold, and
- * scrolling to it on a short viewport would hide the heading for no reason.
+ * is the first thing anyone does here. Skipped on a deep link, where the form is
+ * already what someone came to see, and on touch, where focusing a text input
+ * raises the keyboard unasked. `preventScroll` keeps the heading in view.
  */
 function focusUsernameIfHelpful(deepLinked) {
   if (deepLinked) return;

--- a/public/app.js
+++ b/public/app.js
@@ -130,6 +130,22 @@ const THEME_COLORS = {
     accent: '#d51007',
     loved: '#d51007',
   },
+  dracula: {
+    bg: '#282a36',
+    title: '#f8f8f2',
+    artist: '#bd93f9',
+    meta: '#808db4',
+    accent: '#ff79c6',
+    loved: '#ff5555',
+  },
+  tokyonight: {
+    bg: '#1a1b26',
+    title: '#c0caf5',
+    artist: '#7aa2f7',
+    meta: '#767fa9',
+    accent: '#bb9af7',
+    loved: '#f7768e',
+  },
 };
 
 const el = (id) => document.getElementById(id);

--- a/public/index.html
+++ b/public/index.html
@@ -23,117 +23,296 @@
     <main>
       <div class="split">
         <section aria-label="Options">
-          <div class="field">
-            <div class="field-head">
-              <label for="user">Last.fm username</label>
-              <span class="error" id="user-error" role="alert"></span>
+          <fieldset class="group">
+            <legend>Card</legend>
+            <div class="group-grid">
+              <div class="field span-2">
+                <div class="field-head">
+                  <label for="user">Last.fm username</label>
+                  <span class="error" id="user-error" role="alert"></span>
+                </div>
+                <input
+                  id="user"
+                  type="text"
+                  placeholder="e.g. rj"
+                  autocomplete="off"
+                  autocapitalize="off"
+                  spellcheck="false"
+                />
+              </div>
+
+              <div class="field">
+                <label for="theme">Theme</label>
+                <select id="theme">
+                  <option value="dark">Dark</option>
+                  <option value="legacy">Legacy</option>
+                  <option value="light">Light</option>
+                  <option value="nord">Nord</option>
+                  <option value="catppuccin">Catppuccin</option>
+                  <option value="transparent">Transparent</option>
+                </select>
+              </div>
+
+              <div class="field">
+                <label for="loved">Loved tracks</label>
+                <select id="loved">
+                  <option value="between">Left of track name</option>
+                  <option value="between-all">Left of name, greyed if not loved</option>
+                  <option value="title">Right of track name</option>
+                  <option value="time" selected>Left of timestamp</option>
+                  <option value="off">Hidden</option>
+                </select>
+              </div>
+
+              <!-- Collapsed by default: five rows that most people never touch,
+                   and leaving them open pushed everything below them off the
+                   first screen. The badge is what makes collapsing safe - a
+                   customised color would otherwise be invisible once closed. -->
+              <details class="colors span-2" id="colors-details">
+                <summary>
+                  Customize colors
+                  <span class="badge" id="color-count" hidden></span>
+                </summary>
+
+                <p class="hint">
+                  Each follows the theme until you set it. Dividers, borders and placeholders
+                  are derived from the text color.
+                </p>
+
+                <div class="color-row" data-color="bg-color">
+                  <label for="bg-color">Background</label>
+                  <span class="swatch-wrap">
+                    <input type="color" id="bg-color-swatch" aria-label="Background color picker" />
+                  </span>
+                  <input
+                    id="bg-color"
+                    type="text"
+                    autocomplete="off"
+                    autocapitalize="off"
+                    spellcheck="false"
+                  />
+                  <button type="button" class="reset" data-reset="bg-color" title="Reset to theme">
+                    Reset
+                  </button>
+                </div>
+
+                <div class="color-row" data-color="text-color">
+                  <label for="text-color">Track title</label>
+                  <span class="swatch-wrap">
+                    <input type="color" id="text-color-swatch" aria-label="Track title color picker" />
+                  </span>
+                  <input
+                    id="text-color"
+                    type="text"
+                    autocomplete="off"
+                    autocapitalize="off"
+                    spellcheck="false"
+                  />
+                  <button type="button" class="reset" data-reset="text-color" title="Reset to theme">
+                    Reset
+                  </button>
+                </div>
+
+                <div class="linked-pair" id="artist-meta-pair">
+                  <div class="color-row" data-color="artist-color">
+                    <label for="artist-color">Artist</label>
+                    <span class="swatch-wrap">
+                      <input type="color" id="artist-color-swatch" aria-label="Artist color picker" />
+                    </span>
+                    <input
+                      id="artist-color"
+                      type="text"
+                      autocomplete="off"
+                      autocapitalize="off"
+                      spellcheck="false"
+                    />
+                    <button
+                      type="button"
+                      class="reset"
+                      data-reset="artist-color"
+                      title="Reset to theme"
+                    >
+                      Reset
+                    </button>
+                  </div>
+
+                  <!-- The two are a pair in the neutral themes and deliberately
+                       unalike in nord and catppuccin, so neither one control nor
+                       two unrelated controls is right on its own. Linked by
+                       default, because matching is the common case. -->
+                  <button
+                    type="button"
+                    id="link-artist-meta"
+                    class="link-toggle"
+                    aria-pressed="true"
+                    aria-label="Derive timestamp color from artist color"
+                    title="Derive timestamp color from artist color"
+                  >
+                    <span class="link-arm link-arm-top"></span>
+                    <span class="link-icon">
+                      <svg viewBox="0 0 16 16" aria-hidden="true">
+                        <path class="link-chain" d="M6.4 9.6a3 3 0 0 1 0-4.24l1.9-1.9a3 3 0 0 1 4.24 4.24l-1 1" />
+                        <path class="link-chain" d="M9.6 6.4a3 3 0 0 1 0 4.24l-1.9 1.9a3 3 0 0 1-4.24-4.24l1-1" />
+                        <path class="link-break" d="M3 13 13 3" />
+                      </svg>
+                    </span>
+                    <span class="link-arm link-arm-bottom"></span>
+                  </button>
+
+                  <div class="color-row" data-color="meta-color">
+                    <label for="meta-color">Timestamp</label>
+                    <span class="swatch-wrap">
+                      <input type="color" id="meta-color-swatch" aria-label="Timestamp color picker" />
+                    </span>
+                    <input
+                      id="meta-color"
+                      type="text"
+                      autocomplete="off"
+                      autocapitalize="off"
+                      spellcheck="false"
+                    />
+                    <button type="button" class="reset" data-reset="meta-color" title="Reset to theme">
+                      Reset
+                    </button>
+                  </div>
+                </div>
+
+                <div class="color-row" data-color="accent-color">
+                  <label for="accent-color">Now playing</label>
+                  <span class="swatch-wrap">
+                    <input
+                      type="color"
+                      id="accent-color-swatch"
+                      aria-label="Now playing color picker"
+                    />
+                  </span>
+                  <input
+                    id="accent-color"
+                    type="text"
+                    autocomplete="off"
+                    autocapitalize="off"
+                    spellcheck="false"
+                  />
+                  <button
+                    type="button"
+                    class="reset"
+                    data-reset="accent-color"
+                    title="Reset to theme"
+                  >
+                    Reset
+                  </button>
+                </div>
+
+                <div class="color-row" data-color="loved-color">
+                  <label for="loved-color">Loved heart</label>
+                  <span class="swatch-wrap">
+                    <input
+                      type="color"
+                      id="loved-color-swatch"
+                      aria-label="Loved heart color picker"
+                    />
+                  </span>
+                  <input
+                    id="loved-color"
+                    type="text"
+                    autocomplete="off"
+                    autocapitalize="off"
+                    spellcheck="false"
+                  />
+                  <button
+                    type="button"
+                    class="reset"
+                    data-reset="loved-color"
+                    title="Reset to theme"
+                  >
+                    Reset
+                  </button>
+                </div>
+
+                <div class="color-row" data-color="logo-color">
+                  <label for="logo-color">Last.fm logo</label>
+                  <span class="swatch-wrap">
+                    <input type="color" id="logo-color-swatch" aria-label="Last.fm logo color picker" />
+                  </span>
+                  <input
+                    id="logo-color"
+                    type="text"
+                    autocomplete="off"
+                    autocapitalize="off"
+                    spellcheck="false"
+                  />
+                  <button type="button" class="reset" data-reset="logo-color" title="Reset to brand red">
+                    Reset
+                  </button>
+                </div>
+
+                <p class="color-status" id="color-status" role="status"></p>
+              </details>
             </div>
-            <input
-              id="user"
-              type="text"
-              placeholder="e.g. rj"
-              autocomplete="off"
-              autocapitalize="off"
-              spellcheck="false"
-            />
-          </div>
-
-          <div class="field">
-            <label for="theme">Theme</label>
-            <select id="theme">
-              <option value="dark">Dark</option>
-              <option value="legacy">Legacy</option>
-              <option value="light">Light</option>
-              <option value="nord">Nord</option>
-              <option value="catppuccin">Catppuccin</option>
-              <option value="transparent">Transparent</option>
-            </select>
-          </div>
-
-          <div class="field">
-            <div class="field-head">
-              <label for="bg-color">Background colour</label>
-              <span class="error" id="bg-color-error" role="alert"></span>
-            </div>
-            <input
-              id="bg-color"
-              type="text"
-              placeholder="theme default, e.g. 212121"
-              autocomplete="off"
-              autocapitalize="off"
-              spellcheck="false"
-            />
-          </div>
-
-          <div class="field">
-            <label for="loved">Loved tracks heart indicator</label>
-            <select id="loved">
-              <option value="between">Left of track name</option>
-              <option value="between-all">Left of track name, greyed if not loved</option>
-              <option value="title">Right of track name</option>
-              <option value="time" selected>Left of timestamp</option>
-              <option value="off">Hidden</option>
-            </select>
-          </div>
-
-          <div class="field">
-            <label for="stats">Profile stats</label>
-            <select id="stats">
-              <option value="off">Hidden</option>
-              <option value="block">Columns</option>
-              <option value="block-center">Columns, centred</option>
-              <option value="compact">One line</option>
-            </select>
-          </div>
-
-          <div class="row">
-            <div class="field">
-              <label for="count">Tracks <output id="count-out">5</output></label>
-              <input id="count" type="range" min="1" max="10" value="5" />
-            </div>
-            <div class="field">
-              <label for="width">Width <output id="width-out">400</output>px</label>
-              <input id="width" type="range" min="260" max="1000" step="10" value="400" />
-            </div>
-          </div>
-
-          <div class="field">
-            <label for="radius">Corner radius <output id="radius-out">10</output>px</label>
-            <input id="radius" type="range" min="0" max="40" value="10" />
-          </div>
-
-          <div class="row">
-            <div class="field">
-              <label for="profile">Show profile</label>
-              <select id="profile">
-                <option value="header">Header</option>
-                <option value="footer-left">Footer (left)</option>
-                <option value="footer-right">Footer (right)</option>
-                <option value="off">Hidden</option>
-              </select>
-            </div>
-            <div class="field">
-              <label for="footer">Footer extras</label>
-              <select id="footer">
-                <option value="off">None</option>
-                <option value="stats">Profile stats</option>
-                <option value="wave">Wave</option>
-              </select>
-            </div>
-          </div>
-
-          <fieldset class="toggles">
-            <legend>Profile contents</legend>
-            <label><input type="checkbox" id="username" checked /> Username</label>
-            <label><input type="checkbox" id="avatar" checked /> Picture</label>
           </fieldset>
 
-          <fieldset class="toggles">
-            <legend>Card elements</legend>
-            <label><input type="checkbox" id="header" checked /> Title row</label>
-            <label><input type="checkbox" id="logo" checked /> Last.fm logo</label>
-            <label><input type="checkbox" id="art" checked /> Album art</label>
-            <label><input type="checkbox" id="time" checked /> Timestamps</label>
+          <fieldset class="group">
+            <legend>Size</legend>
+            <div class="group-grid">
+              <div class="field">
+                <label for="count">Tracks <output id="count-out">5</output></label>
+                <input id="count" type="range" min="1" max="10" value="5" />
+              </div>
+              <div class="field">
+                <label for="width">Width <output id="width-out">400</output>px</label>
+                <input id="width" type="range" min="260" max="1000" step="10" value="400" />
+              </div>
+              <div class="field span-2">
+                <label for="radius">Corner radius <output id="radius-out">10</output>px</label>
+                <input id="radius" type="range" min="0" max="40" value="10" />
+              </div>
+            </div>
+          </fieldset>
+
+          <fieldset class="group">
+            <legend>Contents</legend>
+            <div class="group-grid">
+              <div class="field">
+                <label for="profile">Show profile</label>
+                <select id="profile">
+                  <option value="header">Header</option>
+                  <option value="footer-left">Footer (left)</option>
+                  <option value="footer-right">Footer (right)</option>
+                  <option value="off">Hidden</option>
+                </select>
+              </div>
+              <div class="field">
+                <label for="footer">Footer extras</label>
+                <select id="footer">
+                  <option value="off">None</option>
+                  <option value="stats">Profile stats</option>
+                  <option value="wave">Wave</option>
+                </select>
+              </div>
+              <div class="field span-2">
+                <label for="stats">Profile stats</label>
+                <select id="stats">
+                  <option value="off">Hidden</option>
+                  <option value="block">Columns</option>
+                  <option value="block-center">Columns, centred</option>
+                  <option value="compact">One line</option>
+                </select>
+              </div>
+
+              <fieldset class="toggles">
+                <legend>Profile shows</legend>
+                <label><input type="checkbox" id="username" checked /> Username</label>
+                <label><input type="checkbox" id="avatar" checked /> Picture</label>
+              </fieldset>
+
+              <fieldset class="toggles">
+                <legend>Card elements</legend>
+                <label><input type="checkbox" id="header" checked /> Title row</label>
+                <label><input type="checkbox" id="logo" checked /> Last.fm logo</label>
+                <label><input type="checkbox" id="art" checked /> Album art</label>
+                <label><input type="checkbox" id="time" checked /> Timestamps</label>
+              </fieldset>
+            </div>
           </fieldset>
         </section>
 
@@ -142,6 +321,7 @@
             <p id="preview-empty">Enter a username</p>
             <img id="preview" alt="Widget preview" hidden />
           </div>
+          <p class="preview-scale" id="preview-scale" hidden></p>
           <p class="note">
             GitHub proxies README images, so new scrobbles may take up to a few minutes to appear.
           </p>

--- a/public/index.html
+++ b/public/index.html
@@ -47,6 +47,8 @@
                   <option value="dark">Dark</option>
                   <option value="legacy">Legacy</option>
                   <option value="light">Light</option>
+                  <option value="dracula">Dracula</option>
+                  <option value="tokyonight">Tokyo Night</option>
                   <option value="nord">Nord</option>
                   <option value="catppuccin">Catppuccin</option>
                   <option value="transparent">Transparent</option>

--- a/public/styles.css
+++ b/public/styles.css
@@ -15,7 +15,7 @@
 body {
   margin: 0 auto;
   padding: 44px 24px 56px;
-  max-width: 1000px;
+  max-width: 1160px;
   background: var(--bg);
   color: var(--text);
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial,
@@ -48,31 +48,88 @@ h2 {
 }
 
 /* The widget is the only card on the page; everything else is plain sections
-   separated by space and hairlines. */
+   separated by space and hairlines.
+
+   The form gets the larger share. It has around twenty controls and the preview
+   has one image, so the old 320px column grew to roughly three times the height
+   of the column beside it - a tall ribbon of inputs next to a screen of empty
+   space. Laying the short controls out two-up shortens the form enough that the
+   two columns end up comparable. */
 .split {
   display: grid;
-  grid-template-columns: minmax(0, 320px) minmax(0, 1fr);
-  gap: 48px;
+  grid-template-columns: minmax(0, 500px) minmax(0, 1fr);
+  gap: 44px;
   align-items: start;
   margin-top: 36px;
 }
 
-@media (max-width: 780px) {
+/* Keeps the card in view while the form is scrolled. The preview column is
+   shorter than the form, so there is travel for it to stick through. */
+.preview-col {
+  position: sticky;
+  top: 24px;
+}
+
+@media (max-width: 860px) {
   .split {
     grid-template-columns: minmax(0, 1fr);
     gap: 32px;
   }
+
+  /* Stacked, the preview sits after the form, where sticking would pin it over
+     the content below rather than beside it. */
+  .preview-col {
+    position: static;
+  }
 }
 
-.field {
-  margin-bottom: 22px;
+/* Grouped controls. Two columns by default, with `span-2` for anything that
+   needs the full width - a text field, or a slider whose label would wrap. */
+.group {
+  border: 0;
+  padding: 0;
+  margin: 0 0 26px;
   min-width: 0;
 }
 
-.row {
+/* The rule above Embed is its own separation; the last group does not need to
+   add to it. */
+.group:last-of-type {
+  margin-bottom: 0;
+}
+
+.group > legend {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: var(--muted);
+  font-weight: 600;
+  padding: 0;
+  margin-bottom: 12px;
+}
+
+.group-grid {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 16px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px 18px;
+  align-items: end;
+}
+
+.span-2 {
+  grid-column: 1 / -1;
+}
+
+/* One column below the point where two would leave the selects too narrow to
+   read their own option text. */
+@media (max-width: 560px) {
+  .group-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+.field {
+  margin-bottom: 0;
+  min-width: 0;
 }
 
 label {
@@ -117,6 +174,337 @@ input[type='range'] {
   margin: 0;
 }
 
+/* Color rows: label, swatch, hex field, reset. The hex field is what carries
+   alpha and the "inherit from theme" empty state, neither of which a native
+   color input can express. */
+.colors {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0;
+  margin: 0;
+  background: color-mix(in srgb, var(--raised) 45%, transparent);
+}
+
+.colors > summary {
+  cursor: pointer;
+  padding: 10px 12px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--text);
+  /* The page-wide `summary` rule adds a bottom margin for the Image URL
+     disclosure, which here hangs below the summary inside the bordered box and
+     leaves the collapsed section looking padded on one side only. */
+  margin-bottom: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  list-style: none;
+}
+
+/* Only earns a separator once there is something to separate it from. */
+.colors[open] > summary {
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 12px;
+}
+
+.colors > summary::-webkit-details-marker {
+  display: none;
+}
+
+/* A caret drawn rather than relying on the platform marker, which sits
+   inconsistently across browsers when the summary is flex. */
+.colors > summary::before {
+  content: '';
+  width: 0;
+  height: 0;
+  border-left: 4px solid var(--muted);
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  transition: transform 120ms ease;
+}
+
+.colors[open] > summary::before {
+  transform: rotate(90deg);
+}
+
+.colors > summary:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+  border-radius: 8px;
+}
+
+/* Says how many colors are set, so closing the section cannot hide the fact
+   that some are. Without it a customised color is invisible until reopened. */
+.badge {
+  font-size: 0.68rem;
+  font-weight: 600;
+  color: var(--bg);
+  background: var(--accent);
+  border-radius: 999px;
+  padding: 1px 7px;
+}
+
+.colors > *:not(summary) {
+  margin-left: 12px;
+  margin-right: 12px;
+}
+
+.colors > .hint {
+  margin-top: 0;
+  /* Supporting text for the controls below it, so it should read as a caption
+     rather than compete with them. */
+  font-size: 0.72rem;
+  line-height: 1.45;
+}
+
+.colors > .color-status {
+  padding-bottom: 12px;
+}
+
+.color-row {
+  display: grid;
+  /* Wide enough for "Artists & times" on one line - the labels say what will
+     visibly change, which is more use than the name of the parameter. */
+  grid-template-columns: 7.5rem 34px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.color-row label {
+  margin-bottom: 0;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+/* The wrapper carries the border and the checkerboard, so a translucent or
+   unset color is visibly different from an opaque one. */
+.swatch-wrap {
+  display: block;
+  height: 30px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+  background-color: var(--raised);
+}
+
+/* Only where there is real transparency to show. An unset color is inherited,
+   not transparent, and a checkerboard behind it says the wrong thing - the
+   empty field and the hidden Reset already carry "following the theme". */
+.swatch-wrap[data-alpha='true'] {
+  background-image: linear-gradient(45deg, #ffffff14 25%, transparent 25%),
+    linear-gradient(-45deg, #ffffff14 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, #ffffff14 75%),
+    linear-gradient(-45deg, transparent 75%, #ffffff14 75%);
+  background-size: 10px 10px;
+  background-position: 0 0, 0 5px, 5px -5px, -5px 0;
+}
+
+.color-row input[type='color'] {
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  border: 0;
+  background: none;
+  cursor: pointer;
+}
+
+/* Chrome and Firefox each wrap the rendered color in their own padded box.
+   These must stay as separate rules: a selector list containing a prefix the
+   browser does not recognise invalidates the whole rule, so pairing the two
+   vendor pseudo-elements means neither is applied and the UA's own swatch
+   border shows through as a pale edge. */
+.color-row input[type='color']::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.color-row input[type='color']::-webkit-color-swatch {
+  border: 0;
+  border-radius: 0;
+}
+
+.color-row input[type='color']::-moz-color-swatch {
+  border: 0;
+  border-radius: 0;
+}
+
+/* Inherited colors are shown solid: the swatch's job is to say what the card
+   will look like, and dimming it would imply the card is dimmer too. */
+
+.color-row input[type='text'] {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.82rem;
+  padding: 7px 9px;
+}
+
+.reset {
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  color: var(--muted);
+  font: inherit;
+  font-size: 0.72rem;
+  padding: 5px 8px;
+  cursor: pointer;
+}
+
+.reset:hover {
+  color: var(--text);
+  border-color: var(--border);
+}
+
+/* Hidden rather than removed: the row must not reflow when a color is set. */
+.color-row[data-unset='true'] .reset {
+  visibility: hidden;
+}
+
+.color-status {
+  margin: 6px 0 0;
+  font-size: 0.75rem;
+  color: var(--muted);
+  min-height: 1.2em;
+}
+
+/* The link between the artist and timestamp colors: a bracket running from the
+   middle of one swatch to the middle of the other, with the chain sitting on
+   the line. Left of the swatches, so it reads as joining them rather than as a
+   third control in the row. */
+.linked-pair {
+  position: relative;
+  /* The pair owns the gap between its rows, so the bracket can be inset by
+     exactly half a row at each end - which is what makes it begin and end on
+     the swatch centres rather than near them. */
+  margin-bottom: 8px;
+  /* One row: the swatch (30px) plus the text input's slightly taller box. The
+     bracket is inset by half of this at each end, which is what lands it on the
+     swatch centres rather than near them. */
+  --row-h: 36px;
+}
+
+.linked-pair > .color-row:last-of-type {
+  margin-bottom: 0;
+}
+
+.link-toggle {
+  position: absolute;
+  /* The gutter between the label column and the swatch. */
+  left: calc(7.5rem - 6px);
+  top: calc(var(--row-h) / 2);
+  bottom: calc(var(--row-h) / 2);
+  width: 13px;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  padding: 0;
+  background: none;
+  border: 0;
+  color: var(--muted);
+  cursor: pointer;
+}
+
+.link-toggle:hover {
+  color: var(--text);
+}
+
+/* The bracket is 13px wide, which is a fussy thing to hit. This extends the
+   clickable area without moving the drawn line - mostly leftward and
+   vertically, since the swatches sit 1px to the right and stealing clicks from
+   them would be worse than a small target. */
+.link-toggle::before {
+  content: '';
+  position: absolute;
+  inset: -9px -2px -9px -15px;
+}
+
+.link-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+  border-radius: 4px;
+}
+
+/* Two halves of one bracket, each curving away from the chain and running out
+   toward the swatch it belongs to. */
+.link-arm {
+  flex: 1;
+  border-left: 1px solid currentColor;
+}
+
+.link-arm-top {
+  border-top: 1px solid currentColor;
+  border-radius: 5px 0 0 0;
+}
+
+.link-arm-bottom {
+  border-bottom: 1px solid currentColor;
+  border-radius: 0 0 0 5px;
+}
+
+/* Pulled left so the chain straddles the bracket's line instead of hanging off
+   it. */
+.link-icon {
+  display: block;
+  width: 13px;
+  height: 13px;
+  margin: 1px 0 1px -6px;
+}
+
+.link-icon svg {
+  display: block;
+  width: 13px;
+  height: 13px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.6;
+  stroke-linecap: round;
+}
+
+/* Unlinked: the arms stop short of turning toward the swatches and the chain is
+   struck through, so the state reads without waiting for a tooltip. */
+.link-toggle[aria-pressed='false'] .link-arm {
+  border-left-style: dashed;
+  opacity: 0.6;
+}
+
+.link-toggle[aria-pressed='false'] .link-arm-top {
+  border-top-color: transparent;
+}
+
+.link-toggle[aria-pressed='false'] .link-arm-bottom {
+  border-bottom-color: transparent;
+}
+
+.link-break {
+  display: none;
+}
+
+.link-toggle[aria-pressed='false'] .link-break {
+  display: block;
+}
+
+.link-toggle[aria-pressed='false'] .link-chain {
+  opacity: 0.45;
+}
+
+/* Driven by the artist color while linked. The text stays selectable so the
+   value can still be copied - it is `readonly`, not disabled - but the swatch
+   has nothing to offer, so it stops taking clicks. */
+.color-row[data-linked='true'] input[type='text'] {
+  opacity: 0.6;
+}
+
+.color-row[data-linked='true'] input[type='color'] {
+  pointer-events: none;
+  opacity: 0.6;
+}
+
+.color-status[data-level='warn'] {
+  color: #d29922;
+}
+
+.color-status[data-level='error'] {
+  color: var(--accent);
+}
+
 /*
  * Validation sits on the label row rather than under the input. Below the
  * input it either reserves empty space - which makes this field look
@@ -150,6 +538,14 @@ input[type='range'] {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 10px 16px;
+}
+
+/* Inside a group the surrounding grid already provides the spacing, and the two
+   toggle blocks have different numbers of rows - aligning them to the top keeps
+   their rules level with each other. */
+.group-grid > .toggles {
+  margin-bottom: 0;
+  align-self: start;
 }
 
 .toggles legend {
@@ -204,9 +600,18 @@ input[type='range'] {
   max-width: 52ch;
 }
 
+/* Wide cards do not fit the column, and a silently shrunk preview makes the
+   type look smaller than it will be in a README. */
+.preview-scale {
+  margin: 10px 0 0;
+  font-size: 0.75rem;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
 .embed {
-  margin-top: 32px;
-  padding-top: 28px;
+  margin-top: 22px;
+  padding-top: 20px;
   border-top: 1px solid var(--border);
 }
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -58,7 +58,7 @@ export function footerProfileAlign(p: ProfilePosition): 'left' | 'right' | null 
 }
 
 /**
- * A caller-supplied background colour.
+ * A caller-supplied background color.
  *
  * Validated to a strict hex form rather than escaped, because this value is
  * interpolated into an SVG attribute: an allowlist is the only way to be sure
@@ -69,7 +69,7 @@ export function footerProfileAlign(p: ProfilePosition): 'left' | 'right' | null 
  * where everything from the `#` is treated as a page anchor and never reaches
  * the server - which looks like the parameter being ignored.
  */
-export function parseHexColour(raw: string | null): string | null {
+export function parseHexColor(raw: string | null): string | null {
   const value = (raw ?? '').trim().toLowerCase();
   if (!/^([0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/.test(value)) return null;
   if (value.length <= 4) {
@@ -124,6 +124,18 @@ export interface WidgetOptions {
   footer: FooterMode;
   /** Overrides the theme background, or null to keep it. */
   bgColor: string | null;
+  /** Overrides the theme's title color; the supporting greys follow it. */
+  textColor: string | null;
+  /** Overrides the artist line. */
+  artistColor: string | null;
+  /** Overrides timestamps, the footer and the stats labels. */
+  metaColor: string | null;
+  /** Overrides the now-playing accent and the title hover color. */
+  accentColor: string | null;
+  /** Overrides the loved-track heart. */
+  lovedColor: string | null;
+  /** Overrides the Last.fm wordmark, which is otherwise their brand red. */
+  logoColor: string | null;
   /** Where loved-track hearts are drawn. */
   loved: LovedMode;
 }
@@ -196,6 +208,14 @@ export function parseOptions(params: URLSearchParams): WidgetOptions {
     avatar: bool(params.get('avatar'), true),
     stats: parseStats(params.get('stats')),
     footer: parseFooter(params.get('footer')),
-    bgColor: parseHexColour(params.get('bg_color')),
+    bgColor: parseHexColor(params.get('bg_color')),
+    // All colors go through the same allowlist. These are interpolated into
+    // SVG attributes, so validation - not escaping - is what makes them safe.
+    textColor: parseHexColor(params.get('text_color')),
+    artistColor: parseHexColor(params.get('artist_color')),
+    metaColor: parseHexColor(params.get('meta_color')),
+    accentColor: parseHexColor(params.get('accent_color')),
+    lovedColor: parseHexColor(params.get('loved_color')),
+    logoColor: parseHexColor(params.get('logo_color')),
   };
 }

--- a/src/render/card.ts
+++ b/src/render/card.ts
@@ -255,8 +255,8 @@ function link(href: string, body: string, className: string, label?: string): st
 }
 
 /** Hairline rule spanning the content width, centred on `y`. */
-function rule(y: number, width: number, colour: string): string {
-  return `<rect x="${PAD_X}" y="${round(y - 0.5)}" width="${width - PAD_X * 2}" height="1" fill="${colour}"/>`;
+function rule(y: number, width: number, color: string): string {
+  return `<rect x="${PAD_X}" y="${round(y - 0.5)}" width="${width - PAD_X * 2}" height="1" fill="${color}"/>`;
 }
 
 function round(n: number): number {
@@ -267,14 +267,14 @@ function round(n: number): number {
  * Three bars, matching the icon Last.fm uses on its own site. The staggered
  * delays keep them from moving as one block.
  */
-function equaliser(x: number, baseline: number, colour: string, idPrefix: string): string {
+function equaliser(x: number, baseline: number, color: string, idPrefix: string): string {
   const delays = [0, 300, 150];
   const bars = delays
     .map((delay, i) => {
       const bx = x + i * (EQ_BAR_W + EQ_BAR_GAP);
       return (
         `<rect class="${idPrefix}-eq" x="${round(bx)}" y="${round(baseline - EQ_H)}"` +
-        ` width="${EQ_BAR_W}" height="${EQ_H}" rx="1.5" fill="${colour}" style="animation-delay:${delay}ms"/>`
+        ` width="${EQ_BAR_W}" height="${EQ_H}" rx="1.5" fill="${color}" style="animation-delay:${delay}ms"/>`
       );
     })
     .join('');
@@ -410,7 +410,7 @@ function renderHeader(ctx: Ctx, baseline: number, avatarImage: string | null): s
     parts.push(
       link(
         ctx.profileHref,
-        lastfmLogo(PAD_X, baseline, LOGO_H, LASTFM_RED, `${idPrefix}-g`),
+        lastfmLogo(PAD_X, baseline, LOGO_H, options.logoColor ?? LASTFM_RED, `${idPrefix}-g`),
         `${idPrefix}-a`,
         `${options.user} on Last.fm`,
       ),
@@ -730,12 +730,12 @@ function renderStyle(ctx: Ctx): string {
     `.${idPrefix}-eq{transform-box:fill-box;transform-origin:bottom;animation:${idPrefix}-bounce 900ms ease-in-out infinite alternate}` +
     `@keyframes ${idPrefix}-bounce{from{transform:scaleY(0.22)}to{transform:scaleY(1)}}` +
     // Hover resolves only where the SVG is interactive; in an <img> (i.e. on
-    // GitHub) these rules are inert and the card renders in its base colours.
+    // GitHub) these rules are inert and the card renders in its base colors.
     `.${idPrefix}-a{cursor:pointer}` +
     `.${idPrefix}-t,.${idPrefix}-u{transition:fill 180ms ease-in-out}` +
     `.${idPrefix}-g{transition:opacity 180ms ease-in-out}` +
     `.${idPrefix}-a:hover .${idPrefix}-t,.${idPrefix}-a:hover .${idPrefix}-u{fill:${theme.titleHover}}` +
-    // The wordmark fades rather than recolouring: repainting a brand mark
+    // The wordmark fades rather than recoloring: repainting a brand mark
     // would misrepresent it.
     `.${idPrefix}-a:hover .${idPrefix}-g{opacity:0.75}` +
     `@media (prefers-reduced-motion:reduce){.${idPrefix}-eq{animation:none}.${idPrefix}-t,.${idPrefix}-u,.${idPrefix}-g{transition:none}}` +
@@ -755,7 +755,14 @@ export function renderCard({
   avatarImage,
   now = Date.now(),
 }: CardInput): string {
-  const theme = resolveTheme(options.theme);
+  const theme = resolveTheme(options.theme, {
+    bg: options.bgColor,
+    title: options.textColor,
+    artist: options.artistColor,
+    meta: options.metaColor,
+    accent: options.accentColor,
+    loved: options.lovedColor,
+  });
   const { width } = options;
 
   // `between` only earns its gutter if something is actually in it, otherwise
@@ -858,8 +865,9 @@ export function renderCard({
   const height = round(y);
   const altText = buildAltText(tracks);
 
-  // A caller-supplied colour wins over the theme, including over `transparent`.
-  const bg = options.bgColor ?? theme.bg;
+  // The background now comes from the resolved theme, which has already taken
+  // any caller-supplied color into account - including over `transparent`.
+  const bg = theme.bg;
   const background =
     bg === 'none'
       ? ''

--- a/src/render/color.ts
+++ b/src/render/color.ts
@@ -1,0 +1,98 @@
+/**
+ * Color maths for deriving one palette color from another.
+ *
+ * Mixing is in sRGB rather than a perceptual space, because that is how the
+ * presets were built: solving for the mix ratio between `title` and `bg`
+ * reproduces their supporting colors closely, and `legacy`'s greys have zero
+ * channel spread - they *are* sRGB mixes.
+ */
+
+interface Rgba {
+  r: number;
+  g: number;
+  b: number;
+  /** 0-1. Carried through mixes so a translucent input stays translucent. */
+  a: number;
+}
+
+/**
+ * Parses the output of `parseHexColor` - always `#rrggbb` or `#rrggbbaa`,
+ * since that function expands the short forms. Anything else returns null,
+ * including the `none` used by the transparent theme's background.
+ */
+export function parseRgba(color: string): Rgba | null {
+  if (!/^#([0-9a-f]{6}|[0-9a-f]{8})$/i.test(color)) return null;
+  const hex = color.slice(1);
+  return {
+    r: Number.parseInt(hex.slice(0, 2), 16),
+    g: Number.parseInt(hex.slice(2, 4), 16),
+    b: Number.parseInt(hex.slice(4, 6), 16),
+    a: hex.length === 8 ? Number.parseInt(hex.slice(6, 8), 16) / 255 : 1,
+  };
+}
+
+function toHex(value: number): string {
+  return Math.max(0, Math.min(255, Math.round(value)))
+    .toString(16)
+    .padStart(2, '0');
+}
+
+function formatRgba({ r, g, b, a }: Rgba): string {
+  const rgb = `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+  return a >= 1 ? rgb : `${rgb}${toHex(a * 255)}`;
+}
+
+/**
+ * Moves `from` a fraction `t` of the way toward `to`, where 0 keeps `from`.
+ *
+ * Alpha comes from `from`, since `to` is only a reference point to fade toward:
+ * inheriting the background's transparency would make the text vanish. Returns
+ * `from` unchanged when either color is unparseable, so the transparent theme's
+ * `none` yields a usable value rather than a broken attribute.
+ */
+export function mix(from: string, to: string, t: number): string {
+  const a = parseRgba(from);
+  const b = parseRgba(to);
+  if (!a || !b) return from;
+
+  const clamped = Math.max(0, Math.min(1, t));
+  return formatRgba({
+    r: a.r + (b.r - a.r) * clamped,
+    g: a.g + (b.g - a.g) * clamped,
+    b: a.b + (b.b - a.b) * clamped,
+    a: a.a,
+  });
+}
+
+/** WCAG relative luminance. */
+export function relativeLuminance(color: string): number | null {
+  const rgb = parseRgba(color);
+  if (!rgb) return null;
+
+  const channel = (raw: number): number => {
+    const c = raw / 255;
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  };
+
+  return 0.2126 * channel(rgb.r) + 0.7152 * channel(rgb.g) + 0.0722 * channel(rgb.b);
+}
+
+/**
+ * WCAG contrast ratio, 1 (identical) to 21 (black on white). Null when either
+ * color is unparseable, so callers can tell "no opinion" from "poor contrast".
+ */
+export function contrastRatio(a: string, b: string): number | null {
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  if (la === null || lb === null) return null;
+
+  const lighter = Math.max(la, lb);
+  const darker = Math.min(la, lb);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+/** True when `color` is light enough that dark ink reads better on it. */
+export function isLight(color: string): boolean {
+  const luminance = relativeLuminance(color);
+  return luminance !== null && luminance > 0.5;
+}

--- a/src/render/decor.ts
+++ b/src/render/decor.ts
@@ -34,7 +34,7 @@ export function waveDecor(
   y: number,
   width: number,
   height: number,
-  colour: string,
+  color: string,
 ): string {
   const cols = Math.max(28, Math.min(90, Math.round(width / 6.5)));
   const midY = y + height / 2;
@@ -73,7 +73,7 @@ export function waveDecor(
     .map(([opacity, dots]) => `<path opacity="${opacity}" d="${dots.join('')}"/>`)
     .join('');
 
-  return `<g stroke="${colour}" stroke-width="1.7" stroke-linecap="round" fill="none">${groups}</g>`;
+  return `<g stroke="${color}" stroke-width="1.7" stroke-linecap="round" fill="none">${groups}</g>`;
 }
 
 function round1(n: number): number {

--- a/src/render/escape.ts
+++ b/src/render/escape.ts
@@ -28,7 +28,7 @@ export function escapeXml(input: string): string {
 /**
  * Escapes a string for safe use inside an SVG <style> block.
  * Style content is CDATA-ish and is not XML-escaped by the parser, so a stray
- * `</style>` would break out. We only ever emit colour values here, but this
+ * `</style>` would break out. We only ever emit color values here, but this
  * keeps the invariant enforced rather than assumed.
  */
 export function escapeCss(input: string): string {

--- a/src/render/icons.ts
+++ b/src/render/icons.ts
@@ -4,7 +4,7 @@
  * Everything here is drawn as SVG paths rather than embedded raster images.
  * Inside an <img>-rendered SVG we cannot reference external files, so the only
  * alternative would be base64 rasters - which are far larger, blur on HiDPI
- * displays, and cannot be recoloured per theme. Paths solve all three.
+ * displays, and cannot be recolored per theme. Paths solve all three.
  */
 
 /**
@@ -38,9 +38,9 @@ const LOGO_BASELINE_RATIO = 176.25 / LOGO_H;
 const LOGO_OVERSHOOT_RATIO = (179.4 - 176.25) / LOGO_H;
 
 /**
- * Last.fm's brand red. The wordmark is a trademark, so it keeps this colour in
- * every theme rather than taking the theme accent - a teal or pink "last.fm"
- * is no longer their mark. It reads acceptably on all supported backgrounds.
+ * Last.fm's brand red. The wordmark is a trademark, so it defaults to this in
+ * every theme rather than taking the theme accent - a teal or pink "last.fm" is
+ * no longer their mark. `logo_color` can override it deliberately.
  */
 export const LASTFM_RED = '#d51007';
 
@@ -70,14 +70,14 @@ export function lastfmLogo(
   x: number,
   baseline: number,
   height: number,
-  colour: string,
+  color: string,
   className?: string,
 ): string {
   const scale = height / LOGO_H;
   const top = baseline - LOGO_BASELINE_RATIO * height;
   const cls = className ? ` class="${className}"` : '';
   return (
-    `<g${cls} transform="translate(${x},${Math.round(top * 100) / 100}) scale(${scale.toFixed(5)})" fill="${colour}">` +
+    `<g${cls} transform="translate(${x},${Math.round(top * 100) / 100}) scale(${scale.toFixed(5)})" fill="${color}">` +
     `<path d="${LOGO_PATH}"/>` +
     `</g>`
   );
@@ -98,13 +98,13 @@ export const HEART_INK_INSET_RATIO = 2 / 24;
 /**
  * `size` is the rendered box width/height; the heart is centred on (cx, cy).
  */
-export function heart(cx: number, cy: number, size: number, colour: string, opacity = 1): string {
+export function heart(cx: number, cy: number, size: number, color: string, opacity = 1): string {
   const scale = size / 24;
   const x = cx - size / 2;
   const y = cy - size / 2;
   const op = opacity === 1 ? '' : ` opacity="${opacity}"`;
   return (
-    `<g transform="translate(${round(x)},${round(y)}) scale(${scale.toFixed(4)})" fill="${colour}"${op}>` +
+    `<g transform="translate(${round(x)},${round(y)}) scale(${scale.toFixed(4)})" fill="${color}"${op}>` +
     `<path d="${HEART_PATH}"/>` +
     `</g>`
   );
@@ -116,7 +116,7 @@ function round(n: number): number {
 
 /**
  * Vinyl-record tile shown when Last.fm has no cover for a track. Mirrors the
- * shape of Last.fm's own placeholder but drawn in theme colours so it sits in
+ * shape of Last.fm's own placeholder but drawn in theme colors so it sits in
  * the card instead of punching a bright grey hole in it.
  */
 export function vinylPlaceholder(

--- a/src/render/themes.ts
+++ b/src/render/themes.ts
@@ -1,18 +1,20 @@
+import { contrastRatio, isLight, mix, parseRgba } from './color';
+
 export interface Theme {
   /** Card background. `none` renders a transparent card. */
   bg: string;
   border: string;
-  /** Track title colour. */
+  /** Track title color. */
   title: string;
-  /** Artist / secondary line colour. */
+  /** Artist / secondary line color. */
   artist: string;
-  /** Timestamp + footer colour. */
+  /** Timestamp + footer color. */
   meta: string;
   /** Now-playing accent (equaliser bars, "Scrobbling now" label). */
   accent: string;
   /** Placeholder tile fill when album art or an avatar is missing. */
   placeholder: string;
-  /** Glyph colour drawn on top of `placeholder`. */
+  /** Glyph color drawn on top of `placeholder`. */
   placeholderInk: string;
   /** Loved-track heart. Deliberately not `accent`: accent is blue in some
    * palettes, and a blue heart reads as a different thing entirely.
@@ -22,7 +24,7 @@ export interface Theme {
   lovedOff: string;
   /** Hairline rule between track rows. Should be barely perceptible. */
   divider: string;
-  /** Track title colour on hover, where the SVG is interactive. */
+  /** Track title color on hover, where the SVG is interactive. */
   titleHover: string;
 }
 
@@ -138,7 +140,99 @@ export function isThemeName(value: string): value is ThemeName {
   return Object.prototype.hasOwnProperty.call(THEMES, value);
 }
 
-export function resolveTheme(name: string | null | undefined): Theme {
-  if (name && isThemeName(name)) return THEMES[name];
-  return THEMES[DEFAULT_THEME];
+/**
+ * Caller-supplied colors, each null when not given.
+ *
+ * These are roles, not elements: `meta` is the timestamp, the footer and the
+ * stats labels together. Everything else in `Theme` is derived, because it is a
+ * relationship rather than a choice - mixing `title` toward `bg` reproduces the
+ * presets' own dividers and placeholders closely.
+ *
+ * Two pairs look mergeable and are not. `artist` and `meta` differ by 21 and 41
+ * out of 255 in `nord` and `catppuccin`, which pair a hued artist line with a
+ * neutral grey timestamp; and `nord`'s accent is blue, so `loved` cannot follow
+ * it without turning the heart blue.
+ */
+export interface ThemeOverrides {
+  bg?: string | null;
+  title?: string | null;
+  /** The artist line. */
+  artist?: string | null;
+  /** Timestamps, the footer, and the stats labels. */
+  meta?: string | null;
+  accent?: string | null;
+  loved?: string | null;
+}
+
+/** WCAG AA for body text; the card's smaller type is where it matters. */
+const MIN_CONTRAST = 4.5;
+
+/** Ratios measured from the presets - see `color.ts` and the tests. */
+const DERIVED = {
+  artist: 0.31,
+  meta: 0.48,
+  border: 0.89,
+  divider: 0.92,
+  placeholder: 0.92,
+  placeholderInk: 0.77,
+  lovedOff: 0.75,
+} as const;
+
+function hasOverride(overrides: ThemeOverrides | undefined): overrides is ThemeOverrides {
+  return Boolean(overrides && Object.values(overrides).some(Boolean));
+}
+
+export function resolveTheme(
+  name: string | null | undefined,
+  overrides?: ThemeOverrides,
+): Theme {
+  const base: Theme = name && isThemeName(name) ? THEMES[name] : THEMES[DEFAULT_THEME];
+
+  // The common path. Returning the preset object itself - rather than a copy
+  // built from the same values - keeps existing cards provably unchanged.
+  if (!hasOverride(overrides)) return base;
+
+  const bg = overrides.bg ?? base.bg;
+
+  // A background alone can make a theme unreadable - `?bg_color=ffffff` on the
+  // dark theme painted #e9eef5 onto white. Borrow the inks from whichever
+  // built-in palette suits it, which keeps the result looking designed in a way
+  // that computing a contrasting grey does not.
+  const contrast = contrastRatio(bg, base.title);
+  const ink: Theme =
+    contrast !== null && contrast < MIN_CONTRAST ? (isLight(bg) ? THEMES.light : THEMES.dark) : base;
+
+  const title = overrides.title ?? ink.title;
+  const accent = overrides.accent ?? ink.accent;
+  const loved = overrides.loved ?? ink.loved;
+
+  // Supporting colors are only re-derived when the pair they hang off has
+  // moved, and only when there is a background to fade toward: `transparent`
+  // has `bg: 'none'`, and mixing toward nothing collapses them onto the title.
+  const mixable = parseRgba(bg) !== null;
+  const derive = mixable && (title !== ink.title || bg !== ink.bg);
+  const from = (ratio: number, fallback: string): string =>
+    derive ? mix(title, bg, ratio) : fallback;
+
+  return {
+    bg,
+    title,
+    artist: overrides.artist ?? from(DERIVED.artist, ink.artist),
+    accent,
+    loved,
+    meta: overrides.meta ?? from(DERIVED.meta, ink.meta),
+    border: from(DERIVED.border, ink.border),
+    divider: from(DERIVED.divider, ink.divider),
+    placeholder: from(DERIVED.placeholder, ink.placeholder),
+    placeholderInk: from(DERIVED.placeholderInk, ink.placeholderInk),
+    // Tied to the heart rather than the text, so a custom heart keeps its
+    // muted form in the same hue.
+    lovedOff:
+      overrides.loved && mixable
+        ? mix(loved, bg, DERIVED.lovedOff)
+        : from(DERIVED.lovedOff, ink.lovedOff),
+    // The presets mostly set these equal already; where they differ it is a
+    // nudge that only makes sense against that palette's own accent.
+    titleHover: overrides.accent ?? ink.titleHover,
+  };
 }

--- a/src/render/themes.ts
+++ b/src/render/themes.ts
@@ -128,6 +128,38 @@ export const THEMES = {
     divider: '#8b949e33',
     titleHover: '#d51007',
   },
+  dracula: {
+    bg: '#282a36',
+    border: '#44475a',
+    title: '#f8f8f2',
+    artist: '#bd93f9',
+    // Lifted off Dracula's #6272a4 comment colour, which is built to recede in
+    // code and left the timestamp at 3.0 against the card. This is that colour
+    // toward the foreground, so it stays in the palette's family.
+    meta: '#808db4',
+    accent: '#ff79c6',
+    placeholder: '#343746',
+    placeholderInk: '#585961',
+    loved: '#ff5555',
+    lovedOff: '#5e353e',
+    divider: '#393a45',
+    titleHover: '#ff79c6',
+  },
+  tokyonight: {
+    bg: '#1a1b26',
+    border: '#2c2e3d',
+    title: '#c0caf5',
+    artist: '#7aa2f7',
+    /** Lifted off #565f89 for the same reason as Dracula's. */
+    meta: '#767fa9',
+    accent: '#bb9af7',
+    placeholder: '#272937',
+    placeholderInk: '#404356',
+    loved: '#f7768e',
+    lovedOff: '#513240',
+    divider: '#272937',
+    titleHover: '#bb9af7',
+  },
 } as const satisfies Record<string, Theme>;
 
 export type ThemeName = keyof typeof THEMES;

--- a/test/color.test.ts
+++ b/test/color.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { contrastRatio, isLight, mix, parseRgba, relativeLuminance } from '../src/render/color';
+import { THEMES } from '../src/render/themes';
+
+/**
+ * These are the numbers the derived palettes are built on, so they are worth
+ * pinning: a mix that drifts changes every custom card at once, silently and
+ * only in the rendering.
+ */
+
+describe('parseRgba', () => {
+  it('reads the forms parseHexColor produces', () => {
+    expect(parseRgba('#151b23')).toEqual({ r: 21, g: 27, b: 35, a: 1 });
+    expect(parseRgba('#00000080')?.a).toBeCloseTo(0.502, 2);
+  });
+
+  it('rejects anything else, including the transparent theme background', () => {
+    expect(parseRgba('none')).toBeNull();
+    expect(parseRgba('#abc')).toBeNull();
+    expect(parseRgba('red')).toBeNull();
+  });
+});
+
+describe('mix', () => {
+  it('returns the endpoints unchanged', () => {
+    expect(mix('#ffffff', '#000000', 0)).toBe('#ffffff');
+    expect(mix('#ffffff', '#000000', 1)).toBe('#000000');
+  });
+
+  it('interpolates in between', () => {
+    expect(mix('#ffffff', '#000000', 0.5)).toBe('#808080');
+  });
+
+  it('clamps rather than extrapolating', () => {
+    expect(mix('#ffffff', '#000000', -1)).toBe('#ffffff');
+    expect(mix('#ffffff', '#000000', 2)).toBe('#000000');
+  });
+
+  it("keeps the source's alpha, so derived text cannot fade away", () => {
+    expect(mix('#ffffff80', '#000000', 0.5)).toBe('#80808080');
+  });
+
+  it('passes the color through when either end is unparseable', () => {
+    // `transparent` has no background to mix toward.
+    expect(mix('#ffffff', 'none', 0.5)).toBe('#ffffff');
+  });
+
+  /**
+   * The ratios are averages across presets whose supporting colors were picked
+   * by eye, so mixing a theme's own title and background lands near - not on -
+   * its hand-picked values. Measured worst case is 22/255, in `meta` for `nord`
+   * and `border` for `light`, both themes that tint their greys.
+   *
+   * So this is a drift alarm, not a proof of equality: it fails if a ratio is
+   * edited into something unrecognisable, and passes for any value close enough
+   * that derived palettes still look like the presets. Derivation never applies
+   * unless the caller overrides a color, so the presets themselves are never
+   * subject to this error.
+   */
+  it('stays close to the built-in themes the ratios were measured from', () => {
+    const channels = (hex: string): number[] => {
+      const rgba = parseRgba(hex)!;
+      return [rgba.r, rgba.g, rgba.b];
+    };
+    const expectClose = (actual: string, expected: string): void => {
+      const a = channels(actual);
+      for (const [i, value] of channels(expected).entries()) {
+        expect(Math.abs(a[i]! - value)).toBeLessThanOrEqual(25);
+      }
+    };
+
+    for (const theme of [THEMES.legacy, THEMES.dark, THEMES.light, THEMES.nord]) {
+      const { bg, title } = theme;
+      expectClose(mix(title, bg, 0.48), theme.meta);
+      expectClose(mix(title, bg, 0.89), theme.border);
+      expectClose(mix(title, bg, 0.92), theme.divider);
+      expectClose(mix(title, bg, 0.92), theme.placeholder);
+      expectClose(mix(title, bg, 0.77), theme.placeholderInk);
+    }
+  });
+});
+
+describe('contrast', () => {
+  it('matches the WCAG extremes', () => {
+    expect(relativeLuminance('#ffffff')).toBeCloseTo(1, 5);
+    expect(relativeLuminance('#000000')).toBeCloseTo(0, 5);
+    expect(contrastRatio('#ffffff', '#000000')).toBeCloseTo(21, 1);
+    expect(contrastRatio('#ffffff', '#ffffff')).toBeCloseTo(1, 5);
+  });
+
+  it('scores the bug this exists to catch as unreadable', () => {
+    // ?bg_color=ffffff under the dark theme: near-white text on white.
+    expect(contrastRatio('#ffffff', THEMES.dark.title)!).toBeLessThan(1.5);
+    // The same text on the background it was designed for.
+    expect(contrastRatio(THEMES.dark.bg, THEMES.dark.title)!).toBeGreaterThan(4.5);
+  });
+
+  it('has no opinion when a color is unparseable', () => {
+    expect(contrastRatio('none', '#ffffff')).toBeNull();
+    expect(relativeLuminance('none')).toBeNull();
+  });
+
+  it('splits light from dark backgrounds', () => {
+    expect(isLight('#ffffff')).toBe(true);
+    expect(isLight(THEMES.light.bg)).toBe(true);
+    expect(isLight(THEMES.dark.bg)).toBe(false);
+    expect(isLight('none')).toBe(false);
+  });
+});

--- a/test/themes.test.ts
+++ b/test/themes.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import { contrastRatio } from '../src/render/color';
+import { resolveTheme, THEME_NAMES, THEMES } from '../src/render/themes';
+
+describe('resolveTheme', () => {
+  it('returns the preset itself when nothing is overridden', () => {
+    // Identity, not equality: proves existing cards cannot shift by a rounding
+    // error introduced somewhere in the derivation code.
+    for (const name of THEME_NAMES) {
+      expect(resolveTheme(name)).toBe(THEMES[name]);
+      expect(resolveTheme(name, {})).toBe(THEMES[name]);
+      expect(resolveTheme(name, { bg: null, title: null })).toBe(THEMES[name]);
+    }
+  });
+
+  it('falls back to the default theme for an unknown name', () => {
+    expect(resolveTheme('nonsense')).toBe(THEMES.dark);
+    expect(resolveTheme(null)).toBe(THEMES.dark);
+  });
+
+  it('rescues a background that the theme cannot be read on', () => {
+    // The bug this feature started from: white background, near-white text.
+    const resolved = resolveTheme('dark', { bg: '#ffffff' });
+
+    expect(resolved.bg).toBe('#ffffff');
+    expect(contrastRatio(resolved.bg, resolved.title)!).toBeGreaterThan(4.5);
+    // Borrowed from the palette built for light backgrounds rather than an
+    // invented grey.
+    expect(resolved.title).toBe(THEMES.light.title);
+  });
+
+  it('leaves the inks alone when the new background still reads well', () => {
+    const resolved = resolveTheme('dark', { bg: '#101010' });
+    expect(resolved.title).toBe(THEMES.dark.title);
+  });
+
+  it('derives the supporting colors from the text color', () => {
+    const resolved = resolveTheme('legacy', { title: '#ff0000' });
+    const channels = (hex: string): number[] =>
+      [1, 3, 5].map((i) => Number.parseInt(hex.slice(i, i + 2), 16));
+
+    expect(resolved.title).toBe('#ff0000');
+    expect(resolved.meta).not.toBe(THEMES.legacy.meta);
+    expect(resolved.divider).not.toBe(THEMES.legacy.divider);
+
+    // Each derived color keeps the title's hue and sits between it and the
+    // background, which is what "supporting" means here.
+    const [bgR] = channels(THEMES.legacy.bg);
+    for (const derived of [resolved.meta, resolved.border, resolved.divider]) {
+      const [r, g, b] = channels(derived);
+      expect(r!).toBeGreaterThan(g!);
+      expect(r!).toBeGreaterThan(b!);
+      expect(r!).toBeGreaterThan(bgR!);
+      expect(r!).toBeLessThan(255);
+    }
+
+    // And they fade in order: meta is the most readable, divider the least.
+    expect(channels(resolved.meta)[0]!).toBeGreaterThan(channels(resolved.divider)[0]!);
+  });
+
+  it('keeps the artist line and the timestamp independent', () => {
+    // nord pairs a hued artist with a neutral grey timestamp, so one cannot be
+    // derived from the other without turning that grey blue.
+    const artistOnly = resolveTheme('nord', { artist: '#ff0000' });
+    expect(artistOnly.artist).toBe('#ff0000');
+    expect(artistOnly.meta).toBe(THEMES.nord.meta);
+
+    const metaOnly = resolveTheme('nord', { meta: '#ff0000' });
+    expect(metaOnly.meta).toBe('#ff0000');
+    expect(metaOnly.artist).toBe(THEMES.nord.artist);
+  });
+
+  it('does not disturb the greys when only an accent changes', () => {
+    const resolved = resolveTheme('nord', { accent: '#ff0000' });
+
+    expect(resolved.accent).toBe('#ff0000');
+    expect(resolved.titleHover).toBe('#ff0000');
+    expect(resolved.meta).toBe(THEMES.nord.meta);
+    expect(resolved.divider).toBe(THEMES.nord.divider);
+    // nord tints its artist line deliberately; an accent change must not flatten it.
+    expect(resolved.artist).toBe(THEMES.nord.artist);
+  });
+
+  it('keeps a custom heart and its muted form in one hue', () => {
+    const resolved = resolveTheme('dark', { loved: '#00ff00' });
+
+    expect(resolved.loved).toBe('#00ff00');
+    expect(resolved.lovedOff).not.toBe(THEMES.dark.lovedOff);
+    // Faded toward the background, so green rather than the theme's grey.
+    expect(resolved.lovedOff.slice(3, 5)).not.toBe('00');
+  });
+
+  it('never derives against a background it cannot mix toward', () => {
+    // `transparent` has bg: 'none'. Mixing toward it would collapse every
+    // supporting color onto the title.
+    const resolved = resolveTheme('transparent', { title: '#ff0000' });
+
+    expect(resolved.bg).toBe('none');
+    expect(resolved.title).toBe('#ff0000');
+    expect(resolved.meta).toBe(THEMES.transparent.meta);
+    expect(resolved.divider).toBe(THEMES.transparent.divider);
+  });
+
+  it('lets a background promote the transparent theme to an opaque card', () => {
+    const resolved = resolveTheme('transparent', { bg: '#ffffff' });
+
+    expect(resolved.bg).toBe('#ffffff');
+    expect(contrastRatio(resolved.bg, resolved.title)!).toBeGreaterThan(4.5);
+  });
+
+  it('always produces colors that are safe in an SVG attribute', () => {
+    const resolved = resolveTheme('dark', {
+      bg: '#ffffff',
+      title: '#123456',
+      artist: '#abcdef',
+      meta: '#fedcba',
+      accent: '#00000080',
+      loved: '#ff00ff',
+    });
+
+    for (const value of Object.values(resolved)) {
+      expect(value).toMatch(/^(#[0-9a-f]{6}([0-9a-f]{2})?|none)$/);
+    }
+  });
+});

--- a/test/widget.test.ts
+++ b/test/widget.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { isAllowedArtUrl } from '../src/art';
 import { parseRecentTracks } from '../src/lastfm';
-import { OptionsError, parseHexColour, parseOptions } from '../src/options';
+import { OptionsError, parseHexColor, parseOptions } from '../src/options';
 import { relativeTime, renderCard, safeTrackUrl } from '../src/render/card';
 import { THEME_NAMES } from '../src/render/themes';
 import type { Track } from '../src/lastfm';
@@ -30,6 +30,12 @@ const options: WidgetOptions = {
   stats: 'off',
   footer: 'off',
   bgColor: null,
+  textColor: null,
+  artistColor: null,
+  metaColor: null,
+  accentColor: null,
+  lovedColor: null,
+  logoColor: null,
   loved: 'off',
 };
 
@@ -140,7 +146,7 @@ describe('untrusted input', () => {
     expect(parseOptions(new URLSearchParams('user=rj&count=999')).count).toBe(10);
   });
 
-  it('only accepts strict hex colours for the background', () => {
+  it('only accepts strict hex colors for the background', () => {
     for (const [input, expected] of [
       ['1a2b3c', '#1a2b3c'],
       ['ABC', '#aabbcc'],
@@ -155,8 +161,45 @@ describe('untrusted input', () => {
       ['" onload="alert(1)', null],
       ['', null],
     ] as const) {
-      expect(parseHexColour(input), input).toBe(expected);
+      expect(parseHexColor(input), input).toBe(expected);
     }
+  });
+
+  it('routes every color parameter through the same allowlist', () => {
+    // They are interpolated into SVG attributes, so a parameter that skipped
+    // validation would be an injection hole rather than a styling bug.
+    const params = new URLSearchParams({ user: 'rj' });
+    for (const name of [
+      'bg_color',
+      'text_color',
+      'artist_color',
+      'meta_color',
+      'accent_color',
+      'loved_color',
+      'logo_color',
+    ]) {
+      params.set(name, '" onload="alert(1)');
+    }
+
+    const options = parseOptions(params);
+    for (const value of [
+      options.bgColor,
+      options.textColor,
+      options.artistColor,
+      options.metaColor,
+      options.accentColor,
+      options.lovedColor,
+      options.logoColor,
+    ]) {
+      expect(value).toBeNull();
+    }
+  });
+
+  it('leaves the wordmark on the brand red unless asked otherwise', () => {
+    expect(parseOptions(new URLSearchParams('user=rj')).logoColor).toBeNull();
+    expect(parseOptions(new URLSearchParams('user=rj&logo_color=00ff00')).logoColor).toBe(
+      '#00ff00',
+    );
   });
 });
 


### PR DESCRIPTION
The card has six presets and one caller-supplied color, `bg_color`. That single knob can already produce a card nobody can read:

```
?user=rj&bg_color=ffffff     ->  #e9eef5 text on a #ffffff background
```

The background is applied but the theme's text colors aren't reconsidered, so a light background under the dark theme renders near-white on white. That's live today, with no way to fix it.

## Parameters

Six new colors, all optional, all defaulting to the selected theme:

| Parameter | Sets |
| --- | --- |
| `text_color` | track titles, and by derivation the dividers, borders and placeholders |
| `artist_color` | the artist line |
| `meta_color` | timestamps, the footer, the stats labels |
| `accent_color` | now-playing bars, "Scrobbling now", title hover |
| `loved_color` | the loved-track heart |
| `logo_color` | the Last.fm wordmark |

### Why six and not twelve

`Theme` has twelve fields but nowhere near twelve real decisions. Most are the text color mixed toward the background, and solving for that ratio across the presets reproduces their supporting colors closely — `legacy` has zero channel spread, so its greys literally *are* sRGB mixes. Those are derived rather than exposed.

`artist_color` and `meta_color` stay separate because two themes need them to be:

| theme | artist | timestamp | error if one were derived from the other |
| --- | --- | --- | --- |
| dark / legacy / light | — | — | 2–6 |
| **nord** | `#88c0d0` | `#7b88a1` | **21** |
| **catppuccin** | `#cba6f7` | `#7f849c` | **41** |

Both deliberately pair a hued artist line with a neutral grey timestamp, and deriving one from the other turns that grey blue or purple. `loved` stays separate from `accent` for the same reason: nord's accent is blue, and a blue heart reads as something else.

`logo_color` isn't part of `Theme` at all — the wordmark is a trademark, not a palette color — so it defaults to Last.fm's red everywhere and the presets are untouched.

## Contrast

Separately from the new parameters, a background the theme can't be read against now borrows its text colors from whichever built-in palette suits it. `?bg_color=ffffff` on the dark theme gives dark text instead of white-on-white.

## New themes

`dracula` and `tokyonight`, using their canonical palettes.

Neither uses its palette's own comment color for timestamps. Those are built to recede in code, and at 3.0 and 2.8 against the card they'd have been the lowest contrast of any theme here — below `light` and `nord`. Each is lifted toward its theme's foreground until it lands near catppuccin's 4.4.

## Configurator

A collapsed color section with a swatch, hex field and reset per color, and a count badge so customising something isn't hidden by closing it.

Fields show the value the card is actually using rather than a placeholder, so a palette can be read and copied straight out. Which fields count as yours is tracked rather than inferred — comparing against the theme can't tell an untouched field from one deliberately set to the same color. Only tracked fields reach the URL, so an unmodified card still has a two-parameter snippet.

Artist and timestamp are joined by a link toggle between their swatches, which starts linked or unlinked depending on whether the theme's own pair follows that relationship. The link only exists in the page: the URL always carries both colors in full, so the Worker needs no notion of it.

The form is rearranged too. It was a 320px column growing to 1201px tall next to a preview column 584×390 — twenty controls in a ribbon beside most of a screen of nothing:

| | before | after |
| --- | --- | --- |
| Options column | 320 × **1201** | 500 × **795** |
| Page height | 1652 | **1178** |

The preview now takes the extra width, sticks while the form scrolls, and says when it's showing the card smaller than it will render.

## Compatibility

`resolveTheme` returns the preset object itself when nothing is overridden — asserted by identity — so existing cards can't drift. Every color goes through `parseHexColor`; these end up in SVG attributes, so validation is a security boundary rather than a formatting preference.

## Testing

33 tests, up from 8: the color maths, theme resolution, contrast correction, and that all seven color parameters reject hostile input. Tolerances come from measured error against the presets rather than being picked to make the suite pass.

Behaviour was checked by driving the real UI against `wrangler dev` — swatch seeding, theme switching, resets, the link toggle, deep links and badge counts.