### PR TITLE
Allow usernames that start with an underscore

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -6,7 +6,7 @@
  * so a framework and a bundler would be pure overhead.
  */
 
-const USERNAME_RE = /^[a-zA-Z][a-zA-Z0-9_-]{1,29}$/;
+const USERNAME_RE = /^[a-zA-Z_][a-zA-Z0-9_-]{1,29}$/;
 /** Mirrors parseHexColor on the server: hex digits only, no leading hash. */
 const HEX_RE = /^([0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -142,15 +142,15 @@ export interface WidgetOptions {
 
 /**
  * Last.fm usernames are letters, digits, `-` and `_`, and must start with a
- * letter. We validate rather than sanitise: an invalid username can never
- * reach the upstream API, which keeps this endpoint from being used as a
+ * letter or `_`. We validate rather than sanitise: an invalid username can
+ * never reach the upstream API, which keeps this endpoint from being used as a
  * general-purpose probe. (URL construction uses URLSearchParams, so injection
  * is not possible regardless - this is about limiting the request surface.)
  *
  * Last.fm caps signups at 15 characters, but older accounts exceed that, so
  * the bound here is deliberately looser than the signup rule.
  */
-const USERNAME_RE = /^[a-zA-Z][a-zA-Z0-9_-]{1,29}$/;
+const USERNAME_RE = /^[a-zA-Z_][a-zA-Z0-9_-]{1,29}$/;
 
 export class OptionsError extends Error {
   constructor(message: string) {

--- a/test/widget.test.ts
+++ b/test/widget.test.ts
@@ -152,6 +152,10 @@ describe('untrusted input', () => {
     expect(parseOptions(new URLSearchParams('user=rj&count=999')).count).toBe(10);
   });
 
+  it('accepts usernames that start with an underscore', () => {
+    expect(parseOptions(new URLSearchParams('user=_usr_')).user).toBe('_usr_');
+  });
+
   it('only accepts strict hex colors for the background', () => {
     for (const [input, expected] of [
       ['1a2b3c', '#1a2b3c'],


### PR DESCRIPTION
The Worker rewrite required a leading letter, which rejects real Last.fm accounts.

**Summary**
- Accept Last.fm usernames that start with `_`.
- Keep the rest of the username pattern unchanged.

The Cloudflare Worker rewrite validated usernames with `/^[a-zA-Z][a-zA-Z0-9_-]{1,29}$/`, which required a leading letter. Last.fm allows a leading underscore, so those accounts got `Invalid Last.fm username` before any API call.

The same regex is updated in the configurator so the form and the Worker agree.
Tests are also adjusted.